### PR TITLE
Don't let Qrack::Client consumers write to a closed socket

### DIFF
--- a/lib/qrack/client.rb
+++ b/lib/qrack/client.rb
@@ -172,6 +172,9 @@ a hash <tt>{:reply_code, :reply_text, :exchange, :routing_key}</tt>.
 				raise Bunny::ConnectionError, 'No connection - socket has not been created' if !@socket
         @socket.__send__(cmd, *args)
       rescue Errno::EPIPE, IOError => e
+        # Ensure we close the socket when we are down to prevent further
+        # attempts to write to a closed socket
+        close_socket
         raise Bunny::ServerDownError, e.message
       end
     end


### PR DESCRIPTION
I've found cases where calling `Qrack::Client#close()` on an already closed socket will cause the ruby VM to hang. This prevents that from happening by closing the socket when we get an IO error.
