### PR TITLE
Add :content_type option to Exchange#publish

### DIFF
--- a/lib/bunny/exchange08.rb
+++ b/lib/bunny/exchange08.rb
@@ -118,6 +118,7 @@ if any, is committed.
 
 * <tt>:key => 'routing_key'</tt> - Specifies the routing key for the message. The routing key is
   used for routing messages depending on the exchange configuration.
+* <tt>:content_type => 'content/type'</tt> - Specifies the content type to use for the message.
 * <tt>:mandatory => true or false (_default_)</tt> - Tells the server how to react if the message
   cannot be routed to a queue. If set to _true_, the server will return an unroutable message
   with a Return method. If this flag is zero, the server silently drops the message.
@@ -145,6 +146,7 @@ nil
       mandatory = opts.delete(:mandatory)
       immediate = opts.delete(:immediate)
       delivery_mode = opts.delete(:persistent) ? 2 : 1
+      content_type = opts.delete(:content_type) || 'application/octet-stream'
 
       out << Qrack::Protocol::Basic::Publish.new({ :exchange => name,
                                                    :routing_key => routing_key,
@@ -154,7 +156,7 @@ nil
       out << Qrack::Protocol::Header.new(
         Qrack::Protocol::Basic,
         data.bytesize, {
-          :content_type  => 'application/octet-stream',
+          :content_type  => content_type,
           :delivery_mode => delivery_mode,
           :priority      => 0
         }.merge(opts)

--- a/lib/bunny/exchange09.rb
+++ b/lib/bunny/exchange09.rb
@@ -103,6 +103,9 @@ module Bunny
     #   Specifies the routing key for the message. The routing key is
     #   used for routing messages depending on the exchange configuration.
     #
+    # @option opts [String] :content_type
+    #   Specifies the content type for the message.
+    #
     # @option opts [Boolean] :mandatory (false)
     #   Tells the server how to react if the message cannot be routed to a queue.
     #   If set to @true@, the server will return an unroutable message
@@ -130,6 +133,7 @@ module Bunny
       mandatory = opts.delete(:mandatory)
       immediate = opts.delete(:immediate)
       delivery_mode = opts.delete(:persistent) ? 2 : 1
+      content_type = opts.delete(:content_type) || 'application/octet-stream'
 
       out << Qrack::Protocol09::Basic::Publish.new({ :exchange => name,
                                                      :routing_key => routing_key,
@@ -140,7 +144,7 @@ module Bunny
       out << Qrack::Protocol09::Header.new(
                                            Qrack::Protocol09::Basic,
                                            data.bytesize, {
-                                             :content_type  => 'application/octet-stream',
+                                             :content_type  => content_type,
                                              :delivery_mode => delivery_mode,
                                              :priority      => 0
                                            }.merge(opts)


### PR DESCRIPTION
I've added an option to Exchange#publish to allow the user to specify the content type. I'm using Bunny to feed JSON messages to a consumer that requires the content type to be set properly and thought this functionality might be useful for others as well.
