### PR TITLE
Fix the :timeout option to subscribe

### DIFF
--- a/lib/bunny/client08.rb
+++ b/lib/bunny/client08.rb
@@ -151,7 +151,7 @@ Exchange
       when channel.frame_buffer.size > 0
         frame = channel.frame_buffer.shift
       when (timeout = opts[:timeout]) && timeout > 0
-        Bunny::Timer::timeout(timeout, Qrack::ClientTimeout) do
+        Bunny::Timer::timeout(timeout, Qrack::FrameTimeout) do
           frame = Qrack::Transport::Frame.parse(buffer)
         end
       else

--- a/lib/bunny/client09.rb
+++ b/lib/bunny/client09.rb
@@ -125,7 +125,7 @@ module Bunny
       when channel.frame_buffer.size > 0
         frame = channel.frame_buffer.shift
       when (timeout = opts[:timeout]) && timeout > 0
-        Bunny::Timer::timeout(timeout, Qrack::ClientTimeout) do
+        Bunny::Timer::timeout(timeout, Qrack::FrameTimeout) do
           frame = Qrack::Transport09::Frame.parse(buffer)
         end
       else

--- a/lib/bunny/subscription08.rb
+++ b/lib/bunny/subscription08.rb
@@ -50,8 +50,9 @@ Passes a hash of message information to the block, if one has been supplied. The
   :exchange
   :routing_key
 
-If the :timeout option is specified then Qrack::ClientTimeout is raised if method times out
-waiting to receive the next message from the queue.
+If the :timeout option is specified then the subscription will
+automatically cease if the given number of seconds passes with no
+message arriving.
 
 ==== EXAMPLES
 

--- a/lib/bunny/subscription09.rb
+++ b/lib/bunny/subscription09.rb
@@ -54,8 +54,9 @@ module Bunny
   #   :exchange
   #   :routing_key
   #
-  # If the :timeout option is specified then Qrack::ClientTimeout is raised if method times out
-  # waiting to receive the next message from the queue.
+  # If the :timeout option is specified then the subscription will
+  # automatically cease if the given number of seconds passes with no
+  # message arriving.
   #
   # @example
   #   my_queue.subscribe(timeout: 5) { |msg| puts msg[:payload] }

--- a/lib/qrack/client.rb
+++ b/lib/qrack/client.rb
@@ -6,6 +6,7 @@ module Qrack
 
   class ClientTimeout < Timeout::Error; end
   class ConnectionTimeout < Timeout::Error; end
+  class FrameTimeout < Timeout::Error; end
 
   # Client ancestor class
   class Client
@@ -130,7 +131,7 @@ module Qrack
 
       begin
         frame = next_frame(:timeout => opts[:timeout] || 0.1)
-      rescue Qrack::ClientTimeout
+      rescue Qrack::FrameTimeout
         return {:header => nil, :payload => :no_return, :return_details => nil}
       end
 

--- a/lib/qrack/subscription.rb
+++ b/lib/qrack/subscription.rb
@@ -57,7 +57,7 @@ module Qrack
 
         begin
           method = client.next_method(:timeout => timeout)
-        rescue Qrack::ClientTimeout
+        rescue Qrack::FrameTimeout
           queue.unsubscribe
           break
         end


### PR DESCRIPTION
send_command catches Qrack::ClientTimeout, in order to support
@read_write_timeout.  But ClientTimeout can be raised for another reason:
To support the :timeout option in Qrack::Subscription#start.  That
gets mishandled, so using the :timeout option can result in the connection
getting closed.

This separates out the two kinds of timeout.  :socket_timeout continues to
use ClientTimeout.  But the :timeout option now uses FrameTimeout
(as it indicates a timeout in next_frame).
