### PR TITLE
Fix for Client09#tx_setup

### DIFF
--- a/lib/bunny/client09.rb
+++ b/lib/bunny/client09.rb
@@ -358,7 +358,7 @@ module Bunny
 
       method = next_method
 
-      check_response(method, Qrack::Protocol::Tx::SelectOk, "Error initiating transactions for current channel")
+      check_response(method, Qrack::Protocol09::Tx::SelectOk, "Error initiating transactions for current channel")
 
       # return confirmation
       :select_ok


### PR DESCRIPTION
`Client09#tx_setup` has a stray reference to `Qrack::Protocol` instead of `Qrack::Protocol09`

Note: Re-submitting with correct target branch.
