### PR TITLE
Fixed SystemTimer.timeout bug

### DIFF
--- a/lib/bunny.rb
+++ b/lib/bunny.rb
@@ -64,8 +64,8 @@ module Bunny
 
   Timer = if RUBY_VERSION < "1.9"
             begin
-              require 'system_timer'
-              SystemTimer
+              require File.expand_path(File.join(File.dirname(__FILE__), 'timeout.rb'))
+              Bunny::SystemTimer
             rescue LoadError
               Timeout
             end

--- a/lib/bunny/timeout.rb
+++ b/lib/bunny/timeout.rb
@@ -1,0 +1,14 @@
+# encoding: utf-8
+
+module Bunny
+  # Used for ruby < 1.9.x
+  class SystemTimer < ::SystemTimer
+
+    def timeout(seconds, exception)
+      timeout_after(seconds) do
+        yield
+      end
+    end
+
+  end
+end

--- a/spec/spec_09/connection_spec.rb
+++ b/spec/spec_09/connection_spec.rb
@@ -16,4 +16,14 @@ describe Bunny do
     b.host.should eql("tagadab")
   end
 
+  it "should be able to open a TCPSocket with a timeout" do
+    b = Bunny.new
+    connect_timeout = 1
+    lambda { 
+      Bunny::Timer::timeout(connect_timeout, Qrack::ConnectionTimeout) do
+        TCPSocket.new(b.host, b.port) 
+      end
+    }.should_not raise_error(Exception)
+  end
+
 end


### PR DESCRIPTION
Fixed bug with ruby < 1.9 where SystemTimer was calling a method that didn't exist
