### PR TITLE
Pass through ssl_context to SSLSocket.new

### DIFF
--- a/lib/qrack/client.rb
+++ b/lib/qrack/client.rb
@@ -37,6 +37,7 @@ module Qrack
       @logging = opts[:logging] || false
       @ssl = opts[:ssl] || false
       @verify_ssl = opts[:verify_ssl].nil? || opts[:verify_ssl]
+      @ssl_context = opts[:ssl_context].nil? || opts[:ssl_context]
       @status = :not_connected
       @frame_max = opts[:frame_max] || 131072
       @channel_max = opts[:channel_max] || 0
@@ -203,7 +204,11 @@ module Qrack
 
         if @ssl
           require 'openssl' unless defined? OpenSSL::SSL
-          @socket = OpenSSL::SSL::SSLSocket.new(@socket)
+          if @ssl_context
+            @socket = OpenSSL::SSL::SSLSocket.new(@socket, @ssl_context)
+          else
+            @socket = OpenSSL::SSL::SSLSocket.new(@socket)
+          end
           @socket.sync_close = true
           @socket.connect
           @socket.post_connection_check(host) if @verify_ssl


### PR DESCRIPTION
I'm messing around with some SSL options that are not currently
supported by Bunny, like client certificate authentication. The simplest
way I found to get started is this commit, which lets me create an
OpenSSL context object ahead of time, then pass it through to Bunny's
socket calls.

In the long run, this might be the best play. The alternative is
supporting all of the fiddly little ways people use SSL and, especially
fiddly, SSL authentication.

If you don't like this patch, no biggie. I just thought I'd throw it out there in case you're interested. If I find a better way down the road, I'll send it along.

Example:

require 'bunny'
require 'openssl'

ssl_context = OpenSSL::SSL::SSLContext.new()

ssl_context.cert = OpenSSL::X509::Certificate.new(File.open("client-cert.pem"))
ssl_context.key = OpenSSL::PKey::RSA.new(File.open("client-key.pem"))

b = Bunny.new(:logging => true, :ssl => true, :port => 8140, :ssl_context => ssl_context, :ssl_verify => true)
