### PR TITLE
Add support for SSL client certificates

### DIFF
--- a/lib/qrack/client.rb
+++ b/lib/qrack/client.rb
@@ -36,7 +36,8 @@ module Qrack
       @logfile = opts[:logfile] || nil
       @logging = opts[:logging] || false
       @ssl = opts[:ssl] || false
-      @ssl_opts = opts[:ssl_opts] || nil
+      @ssl_cert = opts[:ssl_cert] || nil
+      @ssl_key = opts[:ssl_key] || nil
       @verify_ssl = opts[:verify_ssl].nil? || opts[:verify_ssl]
       @status = :not_connected
       @frame_max = opts[:frame_max] || 131072
@@ -205,7 +206,14 @@ module Qrack
         if @ssl
           require 'openssl' unless defined? OpenSSL::SSL
           sslctx = OpenSSL::SSL::SSLContext.new
-          sslctx.set_params(@ssl_opts)
+          if @ssl_cert
+            cert_file = File.open(@ssl_cert)
+            sslctx.cert = OpenSSL::X509::Certificate.new(cert_file.read)
+          end
+          if @ssl_key
+            key_file = File.open(@ssl_key)
+            sslctx.key = OpenSSL::PKey::RSA.new(key_file.read)
+          end
           @socket = OpenSSL::SSL::SSLSocket.new(@socket, sslctx)
           @socket.sync_close = true
           @socket.connect


### PR DESCRIPTION
This change adds optional parameters when creating a new client - ssl_cert and ssl_key, which represent the path to a X.509 certificate and an RSA private key, so that rabbitmq clients can be authenticated by the rabbitmq server as described here: http://www.rabbitmq.com/ssl.html
