### PR TITLE
Parse a few more AMQP datatypes

### DIFF
--- a/lib/qrack/transport/buffer08.rb
+++ b/lib/qrack/transport/buffer08.rb
@@ -123,6 +123,12 @@ module Qrack
                            table.read(:timestamp)
                          when 70 # 'F'
                            table.read(:table)
+                         when 65 # 'A'
+                           table.read(:array)
+                         when 108 # 'l'
+                           table.read(:longlong)
+                         when 116 # 't'
+                           table.read(:octet)
                          end
             end
 
@@ -134,6 +140,19 @@ module Qrack
             end
 
             @bits.shift
+          when :array
+            a = Array.new
+
+            array = Buffer.new(read(:longstr))
+            until array.empty?
+              type = array.read(:octet)
+              a << case type
+                   when 70 # 'F'
+                     array.read(:table)
+                   end
+            end
+
+            a
           else
             raise Qrack::InvalidTypeError, "Cannot read data of type #{type}"
           end

--- a/lib/qrack/transport/buffer09.rb
+++ b/lib/qrack/transport/buffer09.rb
@@ -123,6 +123,10 @@ module Qrack
                            table.read(:timestamp)
                          when 70 # 'F'
                            table.read(:table)
+                         when 65 # 'A'
+                           table.read(:array)
+                         when 108 # 'l'
+                           table.read(:longlong)
                          when 116 # 't'
                            table.read(:octet)
                          end
@@ -136,6 +140,19 @@ module Qrack
             end
 
             @bits.shift
+          when :array
+            a = Array.new
+
+            array = Buffer.new(read(:longstr))
+            until array.empty?
+              type = array.read(:octet)
+              a << case type
+                   when 70 # 'F'
+                     array.read(:table)
+                   end
+            end
+
+            a
           else
             raise Qrack::InvalidTypeError, "Cannot read data of type #{type}"
           end


### PR DESCRIPTION
Consuming from a RabbitMQ broker that is using the federation plugin
adds an x-received-from: header to messages that currently consists of
an array containing a table that contains a bunch of fields about the
origin broker.

Add support to parse all of the necessary datatypes so these messages
don't generate exceptions.
