### PR TITLE
Issue 43 - added publish headers

### DIFF
--- a/lib/bunny/exchange.rb
+++ b/lib/bunny/exchange.rb
@@ -128,12 +128,16 @@ module Bunny
       opts = opts.dup
       out = []
 
+
       # Set up options
       routing_key = opts.delete(:key) || key
       mandatory = opts.delete(:mandatory)
       immediate = opts.delete(:immediate)
       delivery_mode = opts.delete(:persistent) ? 2 : 1
       content_type = opts.delete(:content_type) || 'application/octet-stream'
+      reply_to = opts.delete(:reply_to)
+      correlation_id = opts.delete(:correlation_id)
+      user_id = opts.delete(:user_id)
 
       out << Qrack::Protocol::Basic::Publish.new({ :exchange => name,
                                                      :routing_key => routing_key,
@@ -146,6 +150,9 @@ module Bunny
                                            data.bytesize, {
                                              :content_type  => content_type,
                                              :delivery_mode => delivery_mode,
+                                             :reply_to => reply_to,
+                                             :correlation_id => correlation_id,
+                                             :user_id => user_id,
                                              :priority      => 0
                                            }.merge(opts)
                                            )

--- a/spec/spec_09/queue_spec.rb
+++ b/spec/spec_09/queue_spec.rb
@@ -84,6 +84,18 @@ describe 'Queue' do
     message_count(q).should == 0
   end
 
+  it "should be able to send reply_to, correlation_id and user_id headers " do
+    q = @b.queue('test1')
+    @default_exchange.publish('This is a test message', :key => 'test1', 
+                              :reply_to => 'test_reply_to',
+                              :correlation_id => '987654',
+                              :user_id => 'guest')
+    msg = q.pop()
+    msg[:header].properties[:reply_to].should == 'test_reply_to'
+    msg[:header].properties[:correlation_id].should == '987654'
+    msg[:header].properties[:user_id].should == 'guest'
+  end
+
   it "should be able to pop a message and just get the payload" do
     q = @b.queue('test1')
     @default_exchange.publish('This is another test message', :key => 'test1')


### PR DESCRIPTION
I have added reply_to, correlation_id and user_id options to the headers on publish on exchange from the advice on 

https://github.com/ruby-amqp/bunny/issues/43

I also added a test to check that it works

Cheers 
Len
