### PR TITLE
Patch to the simple_consumer.rb example.

### DIFF
--- a/examples/simple_consumer.rb
+++ b/examples/simple_consumer.rb
@@ -48,7 +48,7 @@ q.bind(exch, :key => 'fred')
 
 # subscribe to queue
 q.subscribe(:consumer_tag => 'testtag1', :timeout => 30) do |msg|
-  puts "#{q.subscription.message_count}: #{msg[:payload]}"
+  puts "#{q.default_consumer.message_count}: #{msg[:payload]}"
 end
 
 # Close client


### PR DESCRIPTION
`Bunny::Queue` has no `subscription()` method. Instead, it's retrieved via the `default_consumer()` method.
