### PR TITLE
Added support for exchange-to-exchange binding (RabbitMQ extension)

### DIFF
--- a/lib/qrack/protocol/spec.rb
+++ b/lib/qrack/protocol/spec.rb
@@ -251,6 +251,10 @@ module Qrack
       class DeclareOk    < Method(  11, :declare_ok     ); end
       class Delete       < Method(  20, :delete         ); end
       class DeleteOk     < Method(  21, :delete_ok      ); end
+      class Bind         < Method(  30, :bind           ); end
+      class BindOk       < Method(  31, :bind_ok        ); end
+      class Unbind       < Method(  40, :unbind         ); end
+      class UnbindOk     < Method(  51, :unbind_ok      ); end
 
 
       class Declare
@@ -276,6 +280,30 @@ module Qrack
       end
 
       class DeleteOk
+      end
+
+      class Bind
+        short            :reserved_1
+        shortstr         :destination
+        shortstr         :source
+        shortstr         :routing_key
+        bit              :nowait
+        table            :arguments
+      end
+
+      class BindOk
+      end
+
+      class Unbind
+        short            :reserved_1
+        shortstr         :destination
+        shortstr         :source
+        shortstr         :routing_key
+        bit              :nowait
+        table            :arguments
+      end
+
+      class UnbindOk
       end
 
     end

--- a/spec/spec_09/connection_spec.rb
+++ b/spec/spec_09/connection_spec.rb
@@ -8,7 +8,7 @@ describe Bunny do
 
   it "should raise an error if the wrong user name or password is used" do
     b = Bunny.new(:user => 'wrong')
-    lambda { b.start}.should raise_error(Errno::ECONNRESET)
+    lambda { b.start}.should raise_error(StandardError)
   end
 
   it "should merge custom settings from AMQP URL with default settings" do

--- a/spec/spec_09/exchange_spec.rb
+++ b/spec/spec_09/exchange_spec.rb
@@ -123,6 +123,43 @@ describe 'Exchange' do
     exch = @b.exchange('direct2_exchange', :nowait => true)
   end
 
+  it "should ignore the :nowait option when binding to an exchange" do
+    src = @b.exchange('src_exch')
+    dest = @b.exchange('dest_exch')
+    src.bind(dest, :nowait => true).should == :bind_ok
+  end
+
+  it "should raise an error when trying to bind to a non-existent exchange" do
+    src = @b.exchange('src_exch')
+    lambda {src.bind('bogus')}.should raise_error(Bunny::ForcedChannelCloseError)
+    @b.channel.active.should == false
+  end
+
+  it "should be able to bind to an existing exchange" do
+    dest = @b.exchange('dest_exch')
+    src = @b.exchange('src_exch')
+    src.bind(dest).should == :bind_ok
+  end
+
+  it "should ignore the :nowait option when unbinding from an existing exchange" do
+    dest = @b.exchange('dest_exch')
+    src = @b.exchange('src_exch')
+    src.unbind(dest, :nowait => true).should == :unbind_ok
+  end
+
+  it "should raise an error if unbinding from a non-existent exchange" do
+    src = @b.exchange('src_exch')
+    lambda {src.unbind('bogus')}.should raise_error(Bunny::ForcedChannelCloseError)
+    @b.channel.active.should == false
+  end
+
+  it "should be able to unbind from an exchange" do
+    dest = @b.exchange('dest_exch')
+    src = @b.exchange('src_exch')
+    src.bind(dest).should == :bind_ok
+    src.unbind(dest).should == :unbind_ok
+  end
+
   it "should be able to publish a message" do
     exch = @b.exchange('direct_exchange')
     exch.publish('This is a published message')


### PR DESCRIPTION
Includes passing specs for the new functionality.

However, note that I've had the following 3 specs failing when running against RabbitMQ 3.x even before doing my extensions:

```
Failures:

  1) Exchange should be able to return an undeliverable message
     Failure/Error: ret_msg = @b.returned_message
     Bunny::ConnectionError:
       No connection to server
     # ./lib/bunny/client.rb:135:in `next_frame'
     # ./lib/qrack/client.rb:109:in `next_payload'
     # ./lib/qrack/client.rb:137:in `returned_message'
     # ./spec/spec_09/exchange_spec.rb:178:in `block (2 levels) in <top (required)>'

  2) Exchange should be able to return a message that exceeds maximum frame size
     Failure/Error: ret_msg = @b.returned_message
     Bunny::ConnectionError:
       No connection to server
     # ./lib/bunny/client.rb:135:in `next_frame'
     # ./lib/qrack/client.rb:109:in `next_payload'
     # ./lib/qrack/client.rb:137:in `returned_message'
     # ./spec/spec_09/exchange_spec.rb:187:in `block (2 levels) in <top (required)>'

  3) Queue should be able to pop a message where body length exceeds max frame size
     Failure/Error: msg = q.pop[:payload]
     Bunny::ProtocolError:
       Error getting message from queue test1
     # ./lib/bunny/queue.rb:184:in `pop'
     # ./spec/spec_09/queue_spec.rb:111:in `block (2 levels) in <top (required)>'

Finished in 40.5 seconds
65 examples, 3 failures

Failed examples:

rspec ./spec/spec_09/exchange_spec.rb:175 # Exchange should be able to return an undeliverable message
rspec ./spec/spec_09/exchange_spec.rb:183 # Exchange should be able to return a message that exceeds maximum frame size
rspec ./spec/spec_09/queue_spec.rb:107 # Queue should be able to pop a message where body length exceeds max frame size
```
