### PR TITLE
Add license to .gemspec

### DIFF
--- a/bunny.gemspec
+++ b/bunny.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/ruby-amqp/bunny"
   s.summary = "Easy to use synchronous Ruby client for RabbitMQ"
   s.description = "Easy to use synchronous Ruby client for RabbitMQ"
+  s.license = "MIT"
 
   # Sorted alphabetically.
   s.authors = [


### PR DESCRIPTION
There appears to be a licenses field displayed on rubygems.org. I added the license to the .gemspec so that it gets displayed. Cheers.
