### PR TITLE
Correct number of arguments passed to error object

### DIFF
--- a/lib/bunny/transport.rb
+++ b/lib/bunny/transport.rb
@@ -71,7 +71,7 @@ module Bunny
         end
       rescue Errno::EPIPE, Errno::EAGAIN, Bunny::ClientTimeout, IOError => e
         close
-        raise Bunny::ConnectionError, e.message
+        raise Bunny::ConnectionError.new(e.message, @host, @port)
       end
     end
     alias send_raw write


### PR DESCRIPTION
Small change to transport.rb error object instantiation. Cheers.
