### PR TITLE
Small change to publisher_confirms_spec.rb

### DIFF
--- a/spec/higher_level_api/integration/publisher_confirms_spec.rb
+++ b/spec/higher_level_api/integration/publisher_confirms_spec.rb
@@ -29,7 +29,8 @@ describe Bunny::Channel do
 
       ch.next_publish_seq_no.should == 5001
       ch.wait_for_confirms
-
+      sleep 0.25
+      
       q.message_count.should == 5000
       q.purge
 


### PR DESCRIPTION
Test sometimes fails so inserted a small sleep to allow all messages to be confirmed before calling message_count. Cheers.
