### PR TITLE
Fix problem when queue is not created after being deleted and redeclared

### DIFF
--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -18,7 +18,7 @@ module Bunny
     #
 
     attr_accessor :id, :connection, :status, :work_pool
-    attr_reader :next_publish_seq_no
+    attr_reader :next_publish_seq_no, :queues, :exchanges
 
 
     def initialize(connection = nil, id = nil, work_pool = ConsumerWorkPool.new(1))
@@ -730,6 +730,10 @@ module Bunny
     def synchronize(&block)
       @publishing_mutex.synchronize(&block)
     end
+    
+    def deregister_queue(queue)
+      @queues.delete(queue.name)
+    end
 
     def register_queue(queue)
       @queues[queue.name] = queue
@@ -737,6 +741,10 @@ module Bunny
 
     def find_queue(name)
       @queues[name]
+    end
+    
+    def deregister_exchange(exchange)
+      @exchanges.delete(exchange.name)
     end
 
     def register_exchange(exchange)

--- a/lib/bunny/exchange.rb
+++ b/lib/bunny/exchange.rb
@@ -102,6 +102,7 @@ module Bunny
     # Deletes the exchange unless it is a default exchange
     # @api public
     def delete(opts = {})
+      @channel.deregister_exchange(self)
       @channel.exchange_delete(@name, opts) unless predeclared?
     end
 

--- a/lib/bunny/queue.rb
+++ b/lib/bunny/queue.rb
@@ -146,6 +146,7 @@ module Bunny
     # Deletes the queue
     # @api public
     def delete(opts = {})
+      @channel.deregister_queue(self)
       @channel.queue_delete(@name, opts)
     end
 

--- a/spec/higher_level_api/integration/exchange_delete_spec.rb
+++ b/spec/higher_level_api/integration/exchange_delete_spec.rb
@@ -21,6 +21,8 @@ describe Bunny::Exchange, "#delete" do
       expect {
         x.delete
       }.to raise_error(Bunny::NotFound)
+      
+      ch.exchanges.size.should == 0
     end
   end
 

--- a/spec/higher_level_api/integration/queue_delete_spec.rb
+++ b/spec/higher_level_api/integration/queue_delete_spec.rb
@@ -22,6 +22,8 @@ describe Bunny::Queue, "#delete" do
       expect {
         q.delete
       }.to raise_error(Bunny::NotFound)
+      
+      ch.queues.size.should == 0
     end
   end
 


### PR DESCRIPTION
A problem was reported on the ruby-amqp mailing list where a queue was declared, then deleted and finally redeclared. After the last redeclaration the queue was not being recreated because it was still cached in the Bunny::Channel hash @queues.

This patch is to make sure that when exchanges and queues are deleted they are removed from Bunny::Channel hashes @exchanges and @queues.
