### PR TITLE
Global prefetch is not implemented in RabbitMQ

### DIFF
--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -168,11 +168,6 @@ module Bunny
     end
     alias connected? open?
 
-    def prefetch(prefetch_count)
-      self.basic_qos(prefetch_count, true)
-    end
-
-
     #
     # Backwards compatibility
     #


### PR DESCRIPTION
Global prefetch is not implemented in RabbitMQ so remove Bunny::Session#prefetch method
