### PR TITLE
Make Channel#wait_for_confirms block until messages confirmed

### DIFF
--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -578,7 +578,7 @@ module Bunny
       raise_if_no_longer_open!
 
       if @next_publish_seq_no == 0
-        @confirms_continuations = []
+        @confirms_continuations = ::Queue.new
         @unconfirmed_set        = Set.new
         @next_publish_seq_no    = 1
       end


### PR DESCRIPTION
@confirms_continuations was being re-initialized to an Array instead of a thread Queue, so @confirms_continuations.pop call in Channel#wait_for_confirms did not block.

Cheers.
