### PR TITLE
Base Error class for all Bunny Exceptions?

### DIFF
--- a/lib/bunny/exceptions.rb
+++ b/lib/bunny/exceptions.rb
@@ -1,5 +1,8 @@
 module Bunny
-  class TCPConnectionFailed < StandardError
+  # Base exception which can be rescued in client code.
+  class Exception < StandardError; end
+
+  class TCPConnectionFailed < Exception
     attr_reader :hostname, :port
 
     def initialize(e, hostname, port)
@@ -13,7 +16,7 @@ module Bunny
     end
   end
 
-  class ConnectionClosedError < StandardError
+  class ConnectionClosedError < Exception
     def initialize(frame)
       if frame.respond_to?(:method_class)
         super("Trying to send frame through a closed connection. Frame is #{frame.inspect}, method class is #{frame.method_class}")
@@ -23,7 +26,7 @@ module Bunny
     end
   end
 
-  class PossibleAuthenticationFailureError < StandardError
+  class PossibleAuthenticationFailureError < Exception
 
     #
     # API
@@ -44,10 +47,10 @@ module Bunny
   ConnectionError = TCPConnectionFailed
   ServerDownError = TCPConnectionFailed
 
-  class ForcedChannelCloseError < StandardError; end
-  class ForcedConnectionCloseError < StandardError; end
-  class MessageError < StandardError; end
-  class ProtocolError < StandardError; end
+  class ForcedChannelCloseError < Exception; end
+  class ForcedConnectionCloseError < Exception; end
+  class MessageError < Exception; end
+  class ProtocolError < Exception; end
 
   # raised when read or write I/O operations time out (but only if
   # a connection is configured to use them)
@@ -57,7 +60,7 @@ module Bunny
 
 
   # Base exception class for data consistency and framing errors.
-  class InconsistentDataError < StandardError
+  class InconsistentDataError < Exception
   end
 
   # Raised by adapters when frame does not end with {final octet AMQ::Protocol::Frame::FINAL_OCTET}.
@@ -82,7 +85,7 @@ module Bunny
   end
 
 
-  class ChannelAlreadyClosed < StandardError
+  class ChannelAlreadyClosed < Exception
     attr_reader :channel
 
     def initialize(message, ch)
@@ -92,7 +95,7 @@ module Bunny
     end
   end
 
-  class ChannelLevelException < StandardError
+  class ChannelLevelException < Exception
     attr_reader :channel, :channel_close
 
     def initialize(message, ch, channel_close)
@@ -117,7 +120,7 @@ module Bunny
 
 
 
-  class ConnectionLevelException < StandardError
+  class ConnectionLevelException < Exception
     attr_reader :connection, :connection_close
 
     def initialize(message, connection, connection_close)
@@ -137,7 +140,7 @@ module Bunny
   class UnexpectedFrame < ConnectionLevelException
   end
 
-  class NetworkErrorWrapper < StandardError
+  class NetworkErrorWrapper < Exception
     attr_reader :other
 
     def initialize(other)

--- a/spec/lower_level_api/integration/exception_spec.rb
+++ b/spec/lower_level_api/integration/exception_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+describe Bunny::Exception do
+  let(:connection) do
+    c = Bunny.new(:user => "bunny_gem", :password => "bunny_password", :vhost => "bunny_testbed")
+    c.start
+    c
+  end
+
+  after :all do
+    connection.close
+  end
+
+  context "when deleting a non-existent queue" do
+    it "raises an Bunny::Exception" do
+      ch = connection.create_channel
+
+      expect {
+        ch.queue_delete("sdkhflsdjflskdjflsd#{rand}")
+      }.to raise_error(Bunny::Exception)
+    end
+
+    it "raises an Bunny::NotFound" do
+      ch = connection.create_channel
+
+      expect {
+        ch.queue_delete("sdkhflsdjflskdjflsd#{rand}")
+      }.to raise_error(Bunny::NotFound)
+    end
+  end
+end


### PR DESCRIPTION
I notice that there are a number of Error classes defined here:
https://github.com/ruby-amqp/bunny/blob/master/lib/bunny/exceptions.rb

Would it make sense to have them all inherit from one base BunnyException? This would make it easier to rescue specific Bunny exceptions in client code without having to rescue them one by one.

Right now I'm forced to do this and maintain the list in my client code:

``` ruby```
BUNNY_EXCEPTIONS = [Bunny::TCPConnectionFailed, Bunny::ConnectionClosedError,
                      Bunny::PossibleAuthenticationError,
                      Bunny::ForcedChannelCloseError, Bunny::ForcedConnectionCloseError,
                      Bunny::MessageError, Bunny::ProtocolError,
                      Bunny::InconsistentDataError, Bunny::ChannelLevelException,
                      Bunny::ConnectionLevelException, Bunny::NetworkErrorWrapper
begin
  # some bunny code
rescue  *BUNNY_EXCEPTIONS => e
 # handle bunny exceptions
rescue = > e
 # handle all other exceptions
end
```

If it makes sense to do this, I'd be glad to submit a patch. Otherwise if anyone has any suggestions please let me know!

Thanks,
Karthik Hariharan
Desk.com
