### PR TITLE
nack(tag, requeue, multiple) -> nack(tag, multiple, requeue)

### DIFF
--- a/examples/guides/extensions/dead_letter_exchange.rb
+++ b/examples/guides/extensions/dead_letter_exchange.rb
@@ -23,7 +23,7 @@ sleep 0.2
 delivery_info, _, _ = q.pop(:ack => true)
 puts "#{dlq.message_count} messages dead lettered so far"
 puts "Rejecting a message"
-ch.nack(delivery_info.delivery_tag, false)
+ch.nack(delivery_info.delivery_tag)
 sleep 0.2
 puts "#{dlq.message_count} messages dead lettered so far"
 

--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -447,13 +447,13 @@ module Bunny
     # supports rejecting multiple messages at once, and is usually preferred.
     #
     # @param [Integer] delivery_tag Delivery tag to reject
-    # @param [Boolean] requeue      Should this message be requeued instead of dropping it?
     # @param [Boolean] multiple (false) Should all unacknowledged messages up to this be rejected as well?
+    # @param [Boolean] requeue  (false) Should this message be requeued instead of dropping it?
     # @see Bunny::Channel#ack
     # @see http://rubybunny.info/articles/queues.html Queues and Consumers guide
     # @api public
-    def nack(delivery_tag, requeue, multiple = false)
-      basic_nack(delivery_tag, requeue, multiple)
+    def nack(delivery_tag, multiple = false, requeue = false)
+      basic_nack(delivery_tag, multiple, requeue)
     end
 
     # @endgroup
@@ -713,7 +713,7 @@ module Bunny
     #   ch    = conn.create_channel
     #   q.subscribe do |delivery_info, properties, payload|
     #     # requeue the message
-    #     ch.basic_nack(delivery_info.delivery_tag, true)
+    #     ch.basic_nack(delivery_info.delivery_tag, false, true)
     #   end
     #
     # @example Reject a message
@@ -723,7 +723,7 @@ module Bunny
     #   ch    = conn.create_channel
     #   q.subscribe do |delivery_info, properties, payload|
     #     # requeue the message
-    #     ch.basic_nack(delivery_info.delivery_tag, false)
+    #     ch.basic_nack(delivery_info.delivery_tag)
     #   end
     #
     # @example Requeue a message fetched via basic.get
@@ -733,7 +733,7 @@ module Bunny
     #   ch    = conn.create_channel
     #   # we assume the queue exists and has messages
     #   delivery_info, properties, payload = ch.basic_get("bunny.examples.queue3", :ack => true)
-    #   ch.basic_nack(delivery_info.delivery_tag, true)
+    #   ch.basic_nack(delivery_info.delivery_tag, false, true)
     #
     #
     # @example Requeue multiple messages fetched via basic.get
@@ -751,12 +751,12 @@ module Bunny
     # @see http://rubybunny.info/articles/queues.html Queues and Consumers guide
     # @see http://rubybunny.info/articles/extensions.html RabbitMQ Extensions guide
     # @api public
-    def basic_nack(delivery_tag, requeue, multiple = false)
+    def basic_nack(delivery_tag, multiple = false, requeue = false)
       raise_if_no_longer_open!
       @connection.send_frame(AMQ::Protocol::Basic::Nack.encode(@id,
                                                                delivery_tag,
-                                                               requeue,
-                                                               multiple))
+                                                               multiple,
+                                                               requeue))
 
       nil
     end

--- a/spec/higher_level_api/integration/basic_nack_spec.rb
+++ b/spec/higher_level_api/integration/basic_nack_spec.rb
@@ -51,7 +51,7 @@ describe Bunny::Channel, "#nack" do
       subject.on_error do |ch, channel_close|
         @channel_close = channel_close
       end
-      subject.nack(82, true)
+      subject.nack(82, false, true)
 
       sleep 0.5
 

--- a/spec/higher_level_api/integration/dead_lettering_spec.rb
+++ b/spec/higher_level_api/integration/dead_lettering_spec.rb
@@ -24,7 +24,7 @@ describe "A message" do
 
     delivery_info, _, _ = q.pop(:ack => true)
     dlq.message_count.should be_zero
-    ch.nack(delivery_info.delivery_tag, false)
+    ch.nack(delivery_info.delivery_tag)
 
     sleep 0.2
     q.message_count.should be_zero


### PR DESCRIPTION
The basic.nack prototype is:

```
basic.nack(delivery-tag delivery-tag, bit multiple, bit requeue)
```

(see https://github.com/ruby-amqp/amq-protocol/blob/master/lib/amq/protocol/client.rb#L2157 or the rabbitmq specs)

The current implementation swaps the two last arguments.

bunny got some mushrooms instead of carrots that day :)

---

I couldn't run the test suite, so I apologize in advance if my pull request breaks things.
