### PR TITLE
Unbreak Exception rescue clause in heartbeat run loop.

### DIFF
--- a/lib/bunny/heartbeat_sender.rb
+++ b/lib/bunny/heartbeat_sender.rb
@@ -53,7 +53,7 @@ module Bunny
         @logger.error "I/O error in the hearbeat sender: #{ioe.message}"
         stop
       rescue Exception => e
-        @logger.error "I/O error in the hearbeat sender: #{ioe.message}"
+        @logger.error "Error in the hearbeat sender: #{e.message}"
         stop
       end
     end


### PR DESCRIPTION
- Use correct exception variable.
- Adjust error message to be generic.
