### PR TITLE
typo fixes, syntax fixes

### DIFF
--- a/examples/guides/queues/redeliveries.rb
+++ b/examples/guides/queues/redeliveries.rb
@@ -41,7 +41,7 @@ q1.bind(x).subscribe(:ack => true, :block => false) do |delivery_info, propertie
   else
     # some messages are not ack-ed and will remain in the queue for redelivery
     # when app #1 connection is closed (either properly or due to a crash)
-    puts "[consumer1] Got message ##{properties.headers['i']}, SKIPPPED"
+    puts "[consumer1] Got message ##{properties.headers['i']}, SKIPPED"
   end
 end
 

--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -1545,7 +1545,7 @@ module Bunny
               @consumers.delete(method.consumer_tag)
               consumer.handle_cancellation(method)
             rescue Exception => e
-              @logger.error "Got excepton when notifying consumer #{method.consumer_tag} about cancellation!"
+              @logger.error "Got exception when notifying consumer #{method.consumer_tag} about cancellation!"
             end
           end
         else

--- a/lib/bunny/consumer.rb
+++ b/lib/bunny/consumer.rb
@@ -93,13 +93,13 @@ module Bunny
     # @return [Boolean] true if this consumer uses automatic acknowledgement mode
     # @api public
     def automatic_acknowledgement?
-      @no_ack == false
+      !@no_ack
     end
 
     # @return [Boolean] true if this consumer uses manual (explicit) acknowledgement mode
     # @api public
     def manual_acknowledgement?
-      @no_ack == true
+      @no_ack
     end
 
     #

--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -517,7 +517,7 @@ module Bunny
 
       @status = :disconnected
 
-      if !recovering_from_network_failure?
+      unless recovering_from_network_failure?
         @recovering_from_network_failure = true
         if recoverable_network_failure?(exception)
           @logger.warn "Recovering from a network failure..."
@@ -631,7 +631,7 @@ module Bunny
 
     # @private
     def password_from(options)
-      options[:password] || options[:pass] || options [:pwd] || DEFAULT_PASSWORD
+      options[:password] || options[:pass] || options[:pwd] || DEFAULT_PASSWORD
     end
 
     # @private

--- a/lib/bunny/transport.rb
+++ b/lib/bunny/transport.rb
@@ -278,7 +278,7 @@ module Bunny
     protected
 
     def tls_enabled?(opts)
-      opts[:tls] || opts[:ssl] || (opts[:port] == AMQ::Protocol::TLS_PORT) || false
+      opts[:tls] || opts[:ssl] || (opts[:port] == AMQ::Protocol::TLS_PORT)
     end
 
     def tls_certificate_path_from(opts)

--- a/spec/higher_level_api/integration/basic_ack_spec.rb
+++ b/spec/higher_level_api/integration/basic_ack_spec.rb
@@ -12,7 +12,7 @@ describe Bunny::Channel, "#ack" do
   end
 
   context "with a valid (known) delivery tag" do
-    it "acknowleges a message" do
+    it "acknowledges a message" do
       ch = connection.create_channel
       q  = ch.queue("bunny.basic.ack.manual-acks", :exclusive => true)
       x  = ch.default_exchange


### PR DESCRIPTION
did a code inspection, corrected some typos

also there are several cases when local variables in the loop have the same name, and potentially this may cause issues, see variable `i` here and a little above https://github.com/ruby-amqp/bunny/blob/master/spec/stress/concurrent_publishers_stress_spec.rb#L40
