### PR TITLE
Use ENV or connection option if string case succeeds.

### DIFF
--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -114,7 +114,7 @@ module Bunny
              when nil then
                Hash.new
              when String then
-               self.class.parse_uri(connection_string_or_opts)
+               self.class.parse_uri(ENV["RABBITMQ_URL"] || connection_string_or_opts)
              when Hash then
                connection_string_or_opts
              end.merge(optz)


### PR DESCRIPTION
We were experiencing an issue where ENV's were not being honored for connections. The reason is because it would succeed in seeing a String for a connection, but only attempt to use the passed in argument. This adds the OR for environment variable connections.
