### PR TITLE
fixed 100% CPU problem under jruby

### DIFF
--- a/lib/bunny/socket.rb
+++ b/lib/bunny/socket.rb
@@ -38,7 +38,7 @@ module Bunny
       value = ''
       begin
         loop do
-          value << read_nonblock(count - value.bytesize)
+          value << readpartial(count - value.bytesize)
           break if value.bytesize >= count
         end
       rescue EOFError


### PR DESCRIPTION
This change is to address a problem with Bunny locking up using 100% of a processor under jruby on ubuntu 12.04 i64 and ubuntu 10.04 arm after running for some hours.

The problem appears to be an operating system one where an EAGAIN exception is repeatedly raised on read_nonblock.  Since the rescue and retry on retry exception classes exception handling exactly replicates the behaviour of the readpartial() method it seems reasonable to replace the misbehaving read_nonblock() with readpartial().  

This fix is proving stable over time in the above long running systems.
