### PR TITLE
fix tls without peer cert verification

### DIFF
--- a/lib/bunny/transport.rb
+++ b/lib/bunny/transport.rb
@@ -368,7 +368,14 @@ module Bunny
       # setting TLS/SSL version only works correctly when done
       # vis set_params. MK.
       ctx.set_params(:ssl_version => @opts.fetch(:tls_protocol, DEFAULT_TLS_PROTOCOL))
-      ctx.set_params(:verify_mode => OpenSSL::SSL::VERIFY_PEER|OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT) if @verify_peer
+     
+      verify_mode = if @verify_peer
+        OpenSSL::SSL::VERIFY_PEER|OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT
+      else
+        OpenSSL::SSL::VERIFY_NONE
+      end
+
+      ctx.set_params(:verify_mode => verify_mode)
 
       ctx
     end


### PR DESCRIPTION
Without setting the verify mode to VERIFY_NONE, openssl still fails to setup the connection. I didn't see any other TLS tests, so I wasn't sure what unit tests you want for this change.
