### PR TITLE
Ensure TCP_NODELAY is disabled by fixing namespacing

### DIFF
--- a/lib/bunny/cruby/socket.rb
+++ b/lib/bunny/cruby/socket.rb
@@ -16,7 +16,7 @@ module Bunny
     def self.open(host, port, options = {})
       Timeout.timeout(options[:socket_timeout], ClientTimeout) do
         sock = new(host, port)
-        if Socket.constants.include?('TCP_NODELAY') || Socket.constants.include?(:TCP_NODELAY)
+        if ::Socket.constants.include?('TCP_NODELAY') || ::Socket.constants.include?(:TCP_NODELAY)
           sock.setsockopt(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, true)
         end
         sock.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_KEEPALIVE, true) if options.fetch(:keepalive, true)


### PR DESCRIPTION
While using bunny-1.1.0, we discovered an unacceptable latency for publishing messages with confirmation. Between a Bunny client and broker, both running Ubuntu Precise, this latency converges to 40ms for the case of many small messages. After some head-scratching, a packet capture revealed the true cause:

![screen shot 2014-02-09 at 10 39 26 pm](https://f.cloud.github.com/assets/1800798/2175136/042beede-95ba-11e3-99fe-c15d5c47185f.png)

Although both frames are sent in a tight loop, the client machine waits for an ACK before sending the payload. This suggests that Bunny isn't disabling Nagle's algorithm as a read through implies it ought to. After some poking, I discovered the bug:

``` ruby
     ::Socket.constants.include?(:TCP_NODELAY)  # => true
Bunny::Socket.constants.include?(:TCP_NODELAY)  # => false
```

By monkey-patching the implementation, I was able to achieve the desired result:

![statsd airbnb](https://f.cloud.github.com/assets/1800798/2175168/ac09c4dc-95ba-11e3-93d9-a28fb25a8327.png)
