### PR TITLE
Plug heartbeat sender leak in clean_up_on_shutdown

### DIFF
--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -703,6 +703,7 @@ module Bunny
       begin
         shut_down_all_consumer_work_pools!
         maybe_shutdown_reader_loop
+        maybe_shutdown_heartbeat_sender
       rescue ShutdownSignal => sse
         # no-op
       rescue Exception => e


### PR DESCRIPTION
This fixes the thread leak discussed in #196 and https://github.com/ruby-amqp/bunny/issues/195#issuecomment-37608300.
