### PR TITLE
Rescue ::StandardError instead of ::Exception

### DIFF
--- a/lib/bunny/consumer_work_pool.rb
+++ b/lib/bunny/consumer_work_pool.rb
@@ -82,7 +82,7 @@ module Bunny
 
           begin
             callable.call
-          rescue ::Exception => e
+          rescue ::StandardError => e
             # TODO: use connection logger
             $stderr.puts e.class.name
             $stderr.puts e.message


### PR DESCRIPTION
Rescuing `::Exception` in libraries is problematic, for several reasons.
In this instance, it prevents a `SystemExit` from killing the interpreter
correctly.

The exception classes which are under `Exception` and not `StandardError`
are generally those which it makes no sense to attempt to handle in user
code anyway, so catching them (especially in a background thread, where
it's normal to expect a `Thread.abort_on_exception` setting to be
relevant) is misleading.
