### PR TITLE
Fixes the class-level Exchange default initialization

### DIFF
--- a/lib/bunny/exchange.rb
+++ b/lib/bunny/exchange.rb
@@ -55,7 +55,7 @@ module Bunny
     # @return [Exchange] An instance that corresponds to the default exchange (of type direct).
     # @api public
     def self.default(channel_or_connection)
-      self.new(channel_from(channel_or_connection), :direct, AMQ::Protocol::EMPTY_STRING, :no_declare => true)
+      self.new(channel_or_connection, :direct, AMQ::Protocol::EMPTY_STRING, :no_declare => true)
     end
 
     # @param [Bunny::Channel] channel_or_connection Channel this exchange will use. {Bunny::Session} instances are supported only for

--- a/spec/higher_level_api/integration/exchange_declare_spec.rb
+++ b/spec/higher_level_api/integration/exchange_declare_spec.rb
@@ -11,6 +11,15 @@ describe Bunny::Exchange do
     connection.close
   end
 
+  context "of default type" do
+    it "is declared with an empty name" do
+      ch = connection.create_channel
+
+      x = Bunny::Exchange.default(ch)
+
+      x.name.should == ''
+    end
+  end
 
   context "of type fanout" do
     context "with a non-predefined name" do


### PR DESCRIPTION
I was trying to use the class-level `Exchange` default method but it was raising out because that compatibility module was included (not extended).  Rather than also include the module, I just pass the channel_or_connection down to the instance without coercion.

``` ruby
> Bunny::Exchange.default(channel).publish("make clean", routing_key => "tasks")
NoMethodError: undefined method `channel_from' for Bunny::Exchange:Class
    from /Users/litch/.rvm/gems/ruby-2.1.1/gems/bunny-1.2.1/lib/bunny/exchange.rb:58:in `default'
    from (irb):9
    from /Users/litch/.rvm/rubies/ruby-2.1.1/bin/irb:11:in `<main>'
```
