### PR TITLE
If not threaded, just raise exceptions as is

### DIFF
--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -707,7 +707,11 @@ module Bunny
       @continuations.push(method)
 
       clean_up_on_shutdown
-      @origin_thread.terminate_with(@last_connection_error)
+      if threaded?
+        @origin_thread.terminate_with(@last_connection_error)
+      else
+        raise @last_connection_error
+      end
     end
 
     def clean_up_on_shutdown


### PR DESCRIPTION
This code will blow up without this patch:

``` ruby
b = Bunny.new threaded: false
b.start
`rabbitmqctl stop_app`
b.create_channel
```
