### PR TITLE
change return values for tls_enabled?

### DIFF
--- a/lib/bunny/transport.rb
+++ b/lib/bunny/transport.rb
@@ -265,7 +265,9 @@ module Bunny
     protected
 
     def tls_enabled?(opts)
-      opts[:tls] || opts[:ssl] || (opts[:port] == AMQ::Protocol::TLS_PORT) || false
+      return opts[:tls] unless opts[:tls].nil?
+      return opts[:ssl] unless opts[:ssl].nil?
+      (opts[:port] == AMQ::Protocol::TLS_PORT) || false
     end
 
     def tls_certificate_path_from(opts)


### PR DESCRIPTION
By changing the return values, we can use the tls or ssl params to explicitly disable using ssl. For the current code, those two params will be useless as normally (opts[:port] == AMQ::Protocol::TLS_PORT) will return true. I met this issue when trying to push messages to a rabbitmq server where the ssl is not setup...

Errors I met:
1. Using TLS but no client certificate is provided! If RabbitMQ is configured to verify peer certificate, connection upgrade will fail!
2. Errno::ECONNRESET: Connection reset by peer - SSL_connect

Please correct me if I am wrong. Thanks!
