### PR TITLE
"warning: assigned but unused variable - e"

### DIFF
--- a/lib/bunny.rb
+++ b/lib/bunny.rb
@@ -17,7 +17,7 @@ begin
   require "openssl"
 
   require "bunny/ssl_socket"
-rescue LoadError => e
+rescue LoadError
   # no-op
 end
 


### PR DESCRIPTION
This patch eliminates a ruby warning when run with -w option.
