### PR TITLE
Deprecated the `:ack` parameter in favour of `:manual_ack`

### DIFF
--- a/examples/guides/extensions/basic_nack.rb
+++ b/examples/guides/extensions/basic_nack.rb
@@ -18,7 +18,7 @@ q    = ch.queue("", :exclusive => true)
 end
 
 20.times do
-  delivery_info, _, _ = q.pop(:ack => true)
+  delivery_info, _, _ = q.pop(:manual_ack => true)
 
   if delivery_info.delivery_tag == 20
     # requeue them all at once with basic.nack

--- a/examples/guides/extensions/dead_letter_exchange.rb
+++ b/examples/guides/extensions/dead_letter_exchange.rb
@@ -20,7 +20,7 @@ dlq  = ch.queue("", :exclusive => true).bind(dlx)
 x.publish("")
 sleep 0.2
 
-delivery_info, _, _ = q.pop(:ack => true)
+delivery_info, _, _ = q.pop(:manual_ack => true)
 puts "#{dlq.message_count} messages dead lettered so far"
 puts "Rejecting a message"
 ch.nack(delivery_info.delivery_tag)

--- a/examples/guides/queues/redeliveries.rb
+++ b/examples/guides/queues/redeliveries.rb
@@ -29,7 +29,7 @@ x   = ch3.direct("amq.direct")
 q1  = ch1.queue("bunny.examples.acknowledgements.explicit", :auto_delete => false)
 q1.purge
 
-q1.bind(x).subscribe(:ack => true, :block => false) do |delivery_info, properties, payload|
+q1.bind(x).subscribe(:manual_ack => true, :block => false) do |delivery_info, properties, payload|
   # do some work
   sleep(0.2)
 
@@ -46,7 +46,7 @@ q1.bind(x).subscribe(:ack => true, :block => false) do |delivery_info, propertie
 end
 
 q2   = ch2.queue("bunny.examples.acknowledgements.explicit", :auto_delete => false)
-q2.bind(x).subscribe(:ack => true, :block => false) do |delivery_info, properties, payload|
+q2.bind(x).subscribe(:manual_ack => true, :block => false) do |delivery_info, properties, payload|
   # do some work
   sleep(0.2)
 

--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -566,7 +566,8 @@ module Bunny
     # @param [String] queue Queue name
     # @param [Hash] opts Options
     #
-    # @option opts [Boolean] :ack (true) Will this message be acknowledged manually?
+    # @option opts [Boolean] :ack (true) [DEPRECATED] Use :manual_ack instead
+    # @option opts [Boolean] :manual_ack (true) Will this message be acknowledged manually?
     #
     # @return [Array] A triple of delivery info, message properties and message content
     #
@@ -575,15 +576,20 @@ module Bunny
     #   conn.start
     #   ch   = conn.create_channel
     #   # here we assume the queue already exists and has messages
-    #   delivery_info, properties, payload = ch.basic_get("bunny.examples.queue1", :ack => true)
+    #   delivery_info, properties, payload = ch.basic_get("bunny.examples.queue1", :manual_ack => true)
     #   ch.acknowledge(delivery_info.delivery_tag)
     # @see Bunny::Queue#pop
     # @see http://rubybunny.info/articles/queues.html Queues and Consumers guide
     # @api public
-    def basic_get(queue, opts = {:ack => true})
+    def basic_get(queue, opts = {:manual_ack => true})
       raise_if_no_longer_open!
 
-      @connection.send_frame(AMQ::Protocol::Basic::Get.encode(@id, queue, !(opts[:ack])))
+      unless opts[:ack].nil?
+        warn "[DEPRECATION] `:ack` is deprecated.  Please use `:manual_ack` instead."
+        opts[:manual_ack] = opts[:ack]
+      end
+
+      @connection.send_frame(AMQ::Protocol::Basic::Get.encode(@id, queue, !(opts[:manual_ack])))
       # this is a workaround for the edge case when basic_get is called in a tight loop
       # and network goes down we need to perform recovery. The problem is, basic_get will
       # keep blocking the thread that calls it without clear way to constantly unblock it
@@ -675,7 +681,7 @@ module Bunny
     #
     #   ch    = conn.create_channel
     #   # we assume the queue exists and has messages
-    #   delivery_info, properties, payload = ch.basic_get("bunny.examples.queue3", :ack => true)
+    #   delivery_info, properties, payload = ch.basic_get("bunny.examples.queue3", :manual_ack => true)
     #   ch.basic_reject(delivery_info.delivery_tag, true)
     #
     # @see Bunny::Channel#basic_nack
@@ -710,7 +716,7 @@ module Bunny
     #
     #   ch    = conn.create_channel
     #   # we assume the queue exists and has messages
-    #   delivery_info, properties, payload = ch.basic_get("bunny.examples.queue3", :ack => true)
+    #   delivery_info, properties, payload = ch.basic_get("bunny.examples.queue3", :manual_ack => true)
     #   ch.basic_ack(delivery_info.delivery_tag)
     #
     # @example Ack multiple messages fetched via basic.get
@@ -719,9 +725,9 @@ module Bunny
     #
     #   ch    = conn.create_channel
     #   # we assume the queue exists and has messages
-    #   _, _, payload1 = ch.basic_get("bunny.examples.queue3", :ack => true)
-    #   _, _, payload2 = ch.basic_get("bunny.examples.queue3", :ack => true)
-    #   delivery_info, properties, payload3 = ch.basic_get("bunny.examples.queue3", :ack => true)
+    #   _, _, payload1 = ch.basic_get("bunny.examples.queue3", :manual_ack => true)
+    #   _, _, payload2 = ch.basic_get("bunny.examples.queue3", :manual_ack => true)
+    #   delivery_info, properties, payload3 = ch.basic_get("bunny.examples.queue3", :manual_ack => true)
     #   # ack all fetched messages up to payload3
     #   ch.basic_ack(delivery_info.delivery_tag, true)
     #
@@ -769,7 +775,7 @@ module Bunny
     #
     #   ch    = conn.create_channel
     #   # we assume the queue exists and has messages
-    #   delivery_info, properties, payload = ch.basic_get("bunny.examples.queue3", :ack => true)
+    #   delivery_info, properties, payload = ch.basic_get("bunny.examples.queue3", :manual_ack => true)
     #   ch.basic_nack(delivery_info.delivery_tag, false, true)
     #
     #
@@ -779,9 +785,9 @@ module Bunny
     #
     #   ch    = conn.create_channel
     #   # we assume the queue exists and has messages
-    #   _, _, payload1 = ch.basic_get("bunny.examples.queue3", :ack => true)
-    #   _, _, payload2 = ch.basic_get("bunny.examples.queue3", :ack => true)
-    #   delivery_info, properties, payload3 = ch.basic_get("bunny.examples.queue3", :ack => true)
+    #   _, _, payload1 = ch.basic_get("bunny.examples.queue3", :manual_ack => true)
+    #   _, _, payload2 = ch.basic_get("bunny.examples.queue3", :manual_ack => true)
+    #   delivery_info, properties, payload3 = ch.basic_get("bunny.examples.queue3", :manual_ack => true)
     #   # requeue all fetched messages up to payload3
     #   ch.basic_nack(delivery_info.delivery_tag, true, true)
     #

--- a/spec/higher_level_api/integration/basic_ack_spec.rb
+++ b/spec/higher_level_api/integration/basic_ack_spec.rb
@@ -20,7 +20,7 @@ describe Bunny::Channel, "#ack" do
       x.publish("bunneth", :routing_key => q.name)
       sleep 0.5
       q.message_count.should == 1
-      delivery_details, properties, content = q.pop(:ack => true)
+      delivery_details, properties, content = q.pop(:manual_ack => true)
 
       ch.ack(delivery_details.delivery_tag, true)
       q.message_count.should == 0
@@ -57,7 +57,7 @@ describe Bunny::Channel, "#ack" do
       x.publish("bunneth", :routing_key => q.name)
       sleep 0.5
       q.message_count.should == 1
-      _, _, content = q.pop(:ack => true)
+      _, _, content = q.pop(:manual_ack => true)
 
       ch.on_error do |ch, channel_close|
         @channel_close = channel_close
@@ -66,6 +66,33 @@ describe Bunny::Channel, "#ack" do
       sleep 0.25
 
       @channel_close.reply_code.should == AMQ::Protocol::PreconditionFailed::VALUE
+    end
+  end
+
+  context "with a valid (known) delivery tag" do
+    it "gets a depricated message warning for using :ack" do
+      ch = connection.create_channel
+      q  = ch.queue("bunny.basic.ack.manual-acks", :exclusive => true)
+      x  = ch.default_exchange
+
+      x.publish("bunneth", :routing_key => q.name)
+      sleep 0.5
+      q.message_count.should == 1
+
+      orig_stderr = $stderr
+      $stderr = StringIO.new
+
+      delivery_details, properties, content = q.pop(:ack => true)
+
+      $stderr.rewind
+      $stderr.string.chomp.should eq("[DEPRECATION] `:ack` is deprecated.  Please use `:manual_ack` instead.\n[DEPRECATION] `:ack` is deprecated.  Please use `:manual_ack` instead.")
+
+      $stderr = orig_stderr
+
+      ch.ack(delivery_details.delivery_tag, true)
+      q.message_count.should == 0
+
+      ch.close
     end
   end
 end

--- a/spec/higher_level_api/integration/basic_consume_with_objects_spec.rb
+++ b/spec/higher_level_api/integration/basic_consume_with_objects_spec.rb
@@ -44,7 +44,7 @@ describe Bunny::Queue, "#subscribe_with" do
       end
       t.abort_on_exception = true
 
-      q1.subscribe_with(ec, :ack => true)
+      q1.subscribe_with(ec, :manual_ack => true)
       sleep 2
       ch1.close
 

--- a/spec/higher_level_api/integration/basic_nack_spec.rb
+++ b/spec/higher_level_api/integration/basic_nack_spec.rb
@@ -23,7 +23,7 @@ describe Bunny::Channel, "#nack" do
       x.publish("bunneth", :routing_key => q.name)
       sleep(0.5)
       q.message_count.should == 1
-      delivery_info, _, content = q.pop(:ack => true)
+      delivery_info, _, content = q.pop(:manual_ack => true)
 
       subject.nack(delivery_info.delivery_tag, false, false)
       sleep(0.5)
@@ -43,9 +43,9 @@ q = subject.queue("bunny.basic.nack.with-requeue-true-multi-true", :exclusive =>
       end
       sleep(0.5)
       q.message_count.should == 3
-      _, _, _ = q.pop(:ack => true)
-      _, _, _ = q.pop(:ack => true)
-      delivery_info, _, content = q.pop(:ack => true)
+      _, _, _ = q.pop(:manual_ack => true)
+      _, _, _ = q.pop(:manual_ack => true)
+      delivery_info, _, content = q.pop(:manual_ack => true)
 
       subject.nack(delivery_info.delivery_tag, true, true)
       sleep(0.5)
@@ -64,7 +64,7 @@ q = subject.queue("bunny.basic.nack.with-requeue-true-multi-true", :exclusive =>
       x.publish("bunneth", :routing_key => q.name)
       sleep(0.25)
       q.message_count.should == 1
-      _, _, content = q.pop(:ack => true)
+      _, _, content = q.pop(:manual_ack => true)
 
       subject.on_error do |ch, channel_close|
         @channel_close = channel_close

--- a/spec/higher_level_api/integration/basic_reject_spec.rb
+++ b/spec/higher_level_api/integration/basic_reject_spec.rb
@@ -20,7 +20,7 @@ describe Bunny::Channel, "#reject" do
       x.publish("bunneth", :routing_key => q.name)
       sleep(0.5)
       q.message_count.should == 1
-      delivery_info, _, _ = q.pop(:ack => true)
+      delivery_info, _, _ = q.pop(:manual_ack => true)
 
       ch.reject(delivery_info.delivery_tag, true)
       sleep(0.5)
@@ -39,7 +39,7 @@ describe Bunny::Channel, "#reject" do
       x.publish("bunneth", :routing_key => q.name)
       sleep(0.5)
       q.message_count.should == 1
-      delivery_info, _, _ = q.pop(:ack => true)
+      delivery_info, _, _ = q.pop(:manual_ack => true)
 
       ch.reject(delivery_info.delivery_tag, false)
       sleep(0.5)
@@ -59,7 +59,7 @@ describe Bunny::Channel, "#reject" do
       x.publish("bunneth", :routing_key => q.name)
       sleep(0.25)
       q.message_count.should == 1
-      _, _, content = q.pop(:ack => true)
+      _, _, content = q.pop(:manual_ack => true)
 
       ch.on_error do |ch, channel_close|
         @channel_close = channel_close

--- a/spec/higher_level_api/integration/dead_lettering_spec.rb
+++ b/spec/higher_level_api/integration/dead_lettering_spec.rb
@@ -22,7 +22,7 @@ describe "A message" do
     x.publish("")
     sleep 0.2
 
-    delivery_info, _, _ = q.pop(:ack => true)
+    delivery_info, _, _ = q.pop(:manual_ack => true)
     dlq.message_count.should be_zero
     ch.nack(delivery_info.delivery_tag)
 

--- a/spec/higher_level_api/integration/exchange_unbind_spec.rb
+++ b/spec/higher_level_api/integration/exchange_unbind_spec.rb
@@ -25,7 +25,7 @@ describe Bunny::Exchange do
     sleep 0.5
 
     queue.message_count.should be == 1
-    queue.pop(:ack => true)
+    queue.pop(:manual_ack => true)
 
     destination.unbind(source)
     source.publish("")

--- a/spec/higher_level_api/integration/message_properties_access_spec.rb
+++ b/spec/higher_level_api/integration/message_properties_access_spec.rb
@@ -21,7 +21,7 @@ describe Bunny::Queue, "#subscribe" do
     t = Thread.new do
       ch = connection.create_channel
       q = ch.queue(queue_name, :auto_delete => true, :durable => false)
-      q.subscribe(:exclusive => true, :ack => false) do |delivery_info, properties, payload|
+      q.subscribe(:exclusive => true, :manual_ack => false) do |delivery_info, properties, payload|
         metadata = properties
         envelope = delivery_info
       end

--- a/spec/issues/issue78_spec.rb
+++ b/spec/issues/issue78_spec.rb
@@ -27,7 +27,7 @@ unless ENV["CI"]
         ch2 = connection1.create_channel
 
         q   = ch1.queue("", :exclusive => true)
-        q.subscribe(:ack => false, :block => false) do |delivery_info, properties, payload|
+        q.subscribe(:manual_ack => false, :block => false) do |delivery_info, properties, payload|
           delivered_data << payload
         end
         sleep 0.5
@@ -60,7 +60,7 @@ unless ENV["CI"]
         sleep 0.7
         q.message_count.should == 3
 
-        q.subscribe(:ack => false, :block => false) do |delivery_info, properties, payload|
+        q.subscribe(:manual_ack => false, :block => false) do |delivery_info, properties, payload|
           delivered_data << payload
         end
         sleep 0.7


### PR DESCRIPTION
- Added deprecation warning when the `:ack` parameter is used
- Corrected documentation for both `:ack` and `:manual_ack`

Signed-off-by: Henry Jenkins henry.jenkins@aurainfosec.com
