### PR TITLE
Add a method for creating a temporary queue

### DIFF
--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -404,6 +404,16 @@ module Bunny
       register_queue(q)
     end
 
+    # Declares a new server-named queue that is automatically deleted when the
+    # connection is closed.
+    #
+    # @return [Bunny::Queue] Queue that was declared
+    # @see #queue
+    # @api public
+    def temporary_queue(opts = {})
+      queue("", opts.merge(:exclusive => true))
+    end
+
     # @endgroup
 
 


### PR DESCRIPTION
Rather than having the user know the semantics of using an empty queue name and passing in `:exclusive => true`, use an explicitly named method.

``` ruby
# This seems arbitrary and makes no sense for the uninitiated:
queue = channel.queue("", :exclusive => true)

# This is readable and easy to understand:
queue = channel.temporary_queue
```
