### PR TITLE
Allow waiting for all subscribers to finish

### DIFF
--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -1421,6 +1421,18 @@ module Bunny
       "#{name}-#{Time.now.to_i * 1000}-#{Kernel.rand(999_999_999_999)}"
     end
 
+    # Waits for all queue subscribers on this channel to finish. This is
+    # useful if you wish to run several concurrent subscribers.
+    #
+    #     channel.queue("pings").subscribe { ... }
+    #     channel.queue("pongs").subscribe { ... }
+    #     channel.wait_for_subscribers
+    #
+    # @api public
+    def wait_for_subscribers
+      worker_pool.join
+    end
+
     # @endgroup
 
 


### PR DESCRIPTION
I'm not sure if this is the right way to do it – I read the code dealing with `:block => true` and saw that it's implemented this way, so I figured it would work.

Basically, I want to have a script that sets up a number of subscriptions and just blocks. Probably a signal handler would trap INT signals and close the channel, in which case the `wait_for_subscribers` call would return (unless there's something I've misunderstood).

Does this make sense to add, or is there a better way to accomplish what I'm trying to do? And is the method name right?
