### PR TITLE
Fix extra channel being created on recovery.

### DIFF
--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -258,7 +258,7 @@ module Bunny
         @reader_loop = nil
         self.start_reader_loop if threaded?
 
-        @default_channel = self.create_channel
+        @default_channel = self.create_channel unless @default_channel
       rescue Exception => e
         @status_mutex.synchronize { @status = :not_connected }
         raise e
@@ -663,10 +663,7 @@ module Bunny
 
     # @private
     def recover_channels
-      # default channel is reopened right after connection
-      # negotiation is completed, so make sure we do not try to open
-      # it twice. MK.
-      @channels.reject { |n, ch| ch == @default_channel }.each do |n, ch|
+      @channels.each do |n, ch|
         ch.open
 
         ch.recover_from_network_failure


### PR DESCRIPTION
Fixes #245

@default_channel is created by Session.start, which is also called
by Session.recover_from_network_failure. Because no identifier is
passed to Channel.new, on recovery a new @default_channel is created
with the next available identifier.

Session.recover_channels previously contained a check to prevent
@default_channel from being reopened twice by comparing each channel
in @channels to @default_channel. However since Session.start is
called before channel_recovery, and @channels still contains the
old @default_channel, the old @default_channel is also reopened,
resulting in an extra channel.
