### PR TITLE
Uncaught exception handler: log e.inspect and first backtrace line

### DIFF
--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -196,7 +196,7 @@ module Bunny
 
       @recoveries_counter = Bunny::Concurrent::AtomicFixnum.new(0)
       @uncaught_exception_handler = Proc.new do |e, consumer|
-        @logger.error "Uncaught exception from consumer #{consumer.to_s}: #{e.message}"
+        @logger.error "Uncaught exception from consumer #{consumer.to_s}: #{e.inspect} @ #{e.backtrace[0]}"
       end
     end
 


### PR DESCRIPTION
`e.inspect` normally prints both exception class and message, and with the first line of the backtrace it's easier to find where the error occurred.
