### PR TITLE
Fixes issue with ignored inline certs

### DIFF
--- a/lib/bunny/transport.rb
+++ b/lib/bunny/transport.rb
@@ -296,7 +296,7 @@ module Bunny
 
 
     def inline_client_certificate_from(opts)
-      opts[:tls_certificate] || opts[:ssl_cert_string]
+      opts[:tls_certificate] || opts[:ssl_cert_string] || opts[:tls_cert]
     end
 
     def inline_client_key_from(opts)


### PR DESCRIPTION
passing a cert inline with the tls_cert: option failed to recognize the cert. My guess, this isn't turned up by tests because certificate parsing is disabled in the test suite. I wasn't able to get the tests running locally, so I'll leave that bit to the maintainer.
