### PR TITLE
ssl_version/tls_protocol shouldn't be hardcoded

### DIFF
--- a/lib/bunny/transport.rb
+++ b/lib/bunny/transport.rb
@@ -25,10 +25,6 @@ module Bunny
     DEFAULT_READ_TIMEOUT  = 5.0
     DEFAULT_WRITE_TIMEOUT = 5.0
 
-    # Default TLS protocol version to use.
-    # Currently TLSv1, same as in RabbitMQ Java client
-    DEFAULT_TLS_PROTOCOL       = "TLSv1"
-
     attr_reader :session, :host, :port, :socket, :connect_timeout, :read_timeout, :write_timeout, :disconnect_timeout
     attr_reader :tls_context
 
@@ -331,7 +327,7 @@ module Bunny
       @tls_ca_certificates   = opts.fetch(:tls_ca_certificates, default_tls_certificates)
       @verify_peer           = opts[:verify_ssl] || opts[:verify_peer]
 
-      @tls_context = initialize_tls_context(OpenSSL::SSL::SSLContext.new)
+      @tls_context = initialize_tls_context(OpenSSL::SSL::SSLContext.new, opts)
     end
 
     def wrap_in_tls_socket(socket)
@@ -365,7 +361,7 @@ module Bunny
       end
     end
 
-    def initialize_tls_context(ctx)
+    def initialize_tls_context(ctx, opts={})
       ctx.cert       = OpenSSL::X509::Certificate.new(@tls_certificate) if @tls_certificate
       ctx.key        = OpenSSL::PKey::RSA.new(@tls_key) if @tls_key
       ctx.cert_store = if @tls_certificate_store
@@ -384,17 +380,15 @@ module Bunny
         @logger.warn "Using TLS but no client private key is provided!"
       end
 
-      # setting TLS/SSL version only works correctly when done
-      # vis set_params. MK.
-      ctx.set_params(:ssl_version => @opts.fetch(:tls_protocol, DEFAULT_TLS_PROTOCOL))
-
       verify_mode = if @verify_peer
         OpenSSL::SSL::VERIFY_PEER|OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT
       else
         OpenSSL::SSL::VERIFY_NONE
       end
+      ctx.verify_mode = verify_mode
 
-      ctx.set_params(:verify_mode => verify_mode)
+      ssl_version = opts[:tls_protocol] || opts[:ssl_version]
+      ctx.ssl_version = ssl_version if ssl_version
 
       ctx
     end

--- a/spec/higher_level_api/integration/tls_connection_spec.rb
+++ b/spec/higher_level_api/integration/tls_connection_spec.rb
@@ -124,4 +124,51 @@ unless ENV["CI"]
 
     include_examples "successful TLS connection"
   end
+
+
+  describe "TLS connection to RabbitMQ with ssl_version SSLv3 specified" do
+    let(:connection) do
+      c = Bunny.new(:user     => "bunny_gem",
+        :password => "bunny_password",
+        :vhost    => "bunny_testbed",
+        :tls                   => true,
+        :ssl_version           => :SSLv3,
+        :tls_ca_certificates   => ["./spec/tls/cacert.pem"])
+      c.start
+      c
+    end
+
+    after :each do
+      connection.close
+    end
+
+    include_examples "successful TLS connection"
+
+    it "connects using SSLv3" do
+      connection.transport.socket.ssl_version.should == "SSLv3"
+    end
+  end
+
+  describe "TLS connection to RabbitMQ with tls_version TLSv1 specified" do
+    let(:connection) do
+      c = Bunny.new(:user     => "bunny_gem",
+        :password => "bunny_password",
+        :vhost    => "bunny_testbed",
+        :tls                   => true,
+        :tls_protocol           => :TLSv1,
+        :tls_ca_certificates   => ["./spec/tls/cacert.pem"])
+      c.start
+      c
+    end
+
+    after :each do
+      connection.close
+    end
+
+    include_examples "successful TLS connection"
+
+    it "connects using TLSv1" do
+      connection.transport.socket.ssl_version.should == "TLSv1"
+    end
+  end
 end


### PR DESCRIPTION
Fixes #260
- Removes hardcoded `tls_protocol` default
- Adds `ssl_version` option to be consistent with other libraries
- Fixes `tls_protocol`/`ssl_version` setting
- Adds tests for `tls_protocol`/`ssl_version` setting
