### PR TITLE
Fix stopping threads in ConsumerWorkPool

### DIFF
--- a/lib/bunny/consumer_work_pool.rb
+++ b/lib/bunny/consumer_work_pool.rb
@@ -58,7 +58,7 @@ module Bunny
     def pause
       @running = false
 
-      @threads.each { |t| t.stop }
+      @threads.each { |t| t[:running] = false }
     end
 
     def resume
@@ -78,6 +78,8 @@ module Bunny
     def run_loop
       catch(:terminate) do
         loop do
+          Thread.stop if Thread.current[:running] == false
+
           callable = @queue.pop
 
           begin


### PR DESCRIPTION
This code in `Bunny:: ConsumerWorkPool` doesn't work:

``` ruby
    def pause
      @running = false

      @threads.each { |t| t.stop }
    end
```

because instance of `Thread` class haven't `stop` method. Only class `Thread` have this method. If using thread variables we can stop thread in loop.
