### PR TITLE
Document Session options for logging.

### DIFF
--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -113,6 +113,10 @@ module Bunny
     # @option connection_string_or_opts [Integer] :continuation_timeout (4000) Timeout for client operations that expect a response (e.g. {Bunny::Queue#get}), in milliseconds.
     # @option connection_string_or_opts [Integer] :connection_timeout (5) Timeout in seconds for connecting to the server.
     # @option connection_string_or_opts [Proc] :hosts_shuffle_strategy A Proc that reorders a list of host strings, defaults to Array#shuffle
+    # @option connection_string_or_opts [Logger] :logger The logger.  If missing, one is created using :log_file and :log_level.
+    # @option connection_string_or_opts [IO, String] :log_file The file or path to use when creating a logger.  Defaults to STDOUT.
+    # @option connection_string_or_opts [IO, String] :logfile DEPRECATED: use :log_file instead.  The file or path to use when creating a logger.  Defaults to STDOUT.
+    # @option connection_string_or_opts [Integer] :log_level The log level to use when creating a logger.  Defaults to LOGGER::WARN
     #
     # @option optz [String] :auth_mechanism ("PLAIN") Authentication mechanism, PLAIN or EXTERNAL
     # @option optz [String] :locale ("PLAIN") Locale RabbitMQ should use


### PR DESCRIPTION
Document Session#initialize options:
- :logger
- :log_file
- :logfile
- :log_level

One of the guides mentions :logfile and :log_level, but not :logger
nor :logfile.

```
http://rubybunny.info/articles/connecting.html
```

I made the assumption that :logfile is deprecated and documented it as
such.  However, since :logger is useful to me, I decided it must have
been accidentally omitted from the API docs and guide.
