### PR TITLE
Update transport.rb

### DIFF
--- a/lib/bunny/transport.rb
+++ b/lib/bunny/transport.rb
@@ -20,7 +20,7 @@ module Bunny
     #
 
     # Default TCP connection timeout
-    DEFAULT_CONNECTION_TIMEOUT = 5.0
+    DEFAULT_CONNECTION_TIMEOUT = 25.0
 
     DEFAULT_READ_TIMEOUT  = 5.0
     DEFAULT_WRITE_TIMEOUT = 5.0


### PR DESCRIPTION
We have to wait more, when linux resolving connection host when primary DNS fails, in my case I have to set `:connect_timeout` to 50 to get it worked. I guess having DEFAULT_CONNECTION_TIMEOUT = 25 will be enough for general case