### PR TITLE
Remove unused declaration of Exchange.add_default_options

### DIFF
--- a/lib/bunny/exchange.rb
+++ b/lib/bunny/exchange.rb
@@ -246,11 +246,6 @@ module Bunny
     end
 
     # @private
-    def self.add_default_options(name, opts, block)
-      { :exchange => name, :nowait => (block.nil? && !name.empty?) }.merge(opts)
-    end
-
-    # @private
     def self.add_default_options(name, opts)
       # :nowait is always false for Bunny
       h = { :queue => name, :nowait => false }.merge(opts)


### PR DESCRIPTION
The method below,
https://github.com/ruby-amqp/bunny/blob/f3a1902e8930d2382c2bc308793764cf4d5cc83e/lib/bunny/exchange.rb#L254
hides the removed in this PR method declaration.
I cannot find any usage of the removed method declaration.