### PR TITLE
Fix a doc typo regarding the extension of the ci script

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ First, clone the repository and run
 
 then set up RabbitMQ vhosts with
 
-    ./bin/ci/before_build.sh
+    ./bin/ci/before_build
 
 (if needed, set `RABBITMQCTL` env variable to point to `rabbitmqctl` you want to use)
 


### PR DESCRIPTION
The file `./bin/ci/before_build.sh` does not exist