### PR TITLE
updates before_build file path in the readme and specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ from the base directory of the gem:
 
 Next up you'll need to prepare your node for the specs (Only once):
 
-`RABBITMQ_NODENAME=bunny ./bin/ci/before_build.sh`
+`RABBITMQ_NODENAME=bunny ./bin/ci/before_build`
 
 And then run the specs:
 

--- a/spec/higher_level_api/integration/connection_spec.rb
+++ b/spec/higher_level_api/integration/connection_spec.rb
@@ -230,7 +230,7 @@ describe Bunny::Session do
     end
 
     let(:host)     { "127.0.0.1" }
-    # see ./bin/ci/before_build.sh
+    # see ./bin/ci/before_build
     let(:username) { "bunny_gem" }
     let(:password) { "bunny_password" }
     let(:vhost)    { "bunny_testbed" }
@@ -283,7 +283,7 @@ describe Bunny::Session do
     end
 
     let(:host)     { "127.0.0.1" }
-    # see ./bin/ci/before_build.sh
+    # see ./bin/ci/before_build
     let(:username) { "bunny_gem" }
     let(:password) { "bunny_password" }
     let(:vhost)    { "bunny_testbed" }
@@ -332,7 +332,7 @@ describe Bunny::Session do
     end
 
     let(:host)     { "127.0.0.1" }
-    # see ./bin/ci/before_build.sh
+    # see ./bin/ci/before_build
     let(:username) { "bunny_gem" }
     let(:password) { "bunny_password" }
     let(:vhost)    { "bunny_testbed" }
@@ -366,7 +366,7 @@ describe Bunny::Session do
 
   context "initialized with :host => 127.0.0.1 and INVALID credentials" do
     let(:host)     { "127.0.0.1" }
-    # see ./bin/ci/before_build.sh
+    # see ./bin/ci/before_build
     let(:username) { "bunny_gem#{Time.now.to_i}" }
     let(:password) { "sdjkfhsdf8ysd8fy8" }
     let(:vhost)    { "___sd89aysd98789" }


### PR DESCRIPTION
the readme and comments in the spec had the incorrect path after the file extension was dropped in c998b68