### PR TITLE
Consistent log output when providing logger

### DIFF
--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -144,10 +144,11 @@ module Bunny
       @user            = self.username_from(opts)
       @pass            = self.password_from(opts)
       @vhost           = self.vhost_from(opts)
-      @logfile         = opts[:log_file] || opts[:logfile] || STDOUT
       @threaded        = opts.fetch(:threaded, true)
 
-      @logger          = opts.fetch(:logger, init_logger(opts[:log_level] || ENV["BUNNY_LOG_LEVEL"] || Logger::WARN))
+      log_file         = opts[:log_file] || opts[:logfile] || STDOUT
+      log_level        = opts[:log_level] || ENV["BUNNY_LOG_LEVEL"] || Logger::WARN
+      @logger          = opts.fetch(:logger, init_logger(log_file, log_level))
 
       # should automatic recovery from network failures be used?
       @automatically_recover = if opts[:automatically_recover].nil? && opts[:automatic_recovery].nil?
@@ -1162,8 +1163,8 @@ module Bunny
     end
 
     # @private
-    def init_logger(level)
-      lgr          = ::Logger.new(@logfile)
+    def init_logger(log_file, level)
+      lgr          = ::Logger.new(log_file)
       lgr.level    = normalize_log_level(level)
       lgr.progname = self.to_s
 

--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -148,7 +148,7 @@ module Bunny
 
       log_file         = opts[:log_file] || opts[:logfile] || STDOUT
       log_level        = opts[:log_level] || ENV["BUNNY_LOG_LEVEL"] || Logger::WARN
-      @logger          = opts.fetch(:logger, init_logger(log_file, log_level))
+      @logger          = opts.fetch(:logger, init_default_logger(log_file, log_level))
 
       # should automatic recovery from network failures be used?
       @automatically_recover = if opts[:automatically_recover].nil? && opts[:automatic_recovery].nil?
@@ -1109,8 +1109,8 @@ module Bunny
         @transport.close rescue nil # Let's make sure the previous transport socket is closed
         @transport = Transport.new(self, host, @port, @opts.merge(:session_thread => @origin_thread))
 
-        # Reset the cached progname for the logger
-        @logger.progname = to_s if @logger.respond_to?(:progname)
+        # Reset the cached progname for the logger only when no logger was provided
+        @default_logger.progname = self.to_s
 
         @transport
       else
@@ -1163,12 +1163,13 @@ module Bunny
     end
 
     # @private
-    def init_logger(log_file, level)
-      lgr          = ::Logger.new(log_file)
-      lgr.level    = normalize_log_level(level)
-      lgr.progname = self.to_s
-
-      lgr
+    def init_default_logger(logfile, level)
+      @default_logger = begin
+                          lgr = ::Logger.new(logfile)
+                          lgr.level    = normalize_log_level(level)
+                          lgr.progname = self.to_s
+                          lgr
+                        end
     end
 
     # @private

--- a/spec/higher_level_api/integration/connection_spec.rb
+++ b/spec/higher_level_api/integration/connection_spec.rb
@@ -435,5 +435,10 @@ describe Bunny::Session do
 
       conn.close
     end
+
+    it "doesn't reassign the logger's progname attribute" do
+      expect(logger).not_to receive(:progname=)
+      described_class.new(:hostname => "localhost", :logger => logger)
+    end
   end
 end


### PR DESCRIPTION
The progname attribute of the logger was being reassigned.
This made for unexpected output when clients provided a custom logger.
fixes #296