### PR TITLE
Sprucing up the Channel#basic_... methods

### DIFF
--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -468,9 +468,7 @@ module Bunny
     # @see http://rubybunny.info/articles/queues.html Queues and Consumers guide
     # @api public
     def reject(delivery_tag, requeue = false)
-      guarding_against_stale_delivery_tags(delivery_tag) do
-        basic_reject(delivery_tag.to_i, requeue)
-      end
+      basic_reject(delivery_tag.to_i, requeue)
     end
 
     # Acknowledges a message. Acknowledged messages are completely removed from the queue.
@@ -481,9 +479,7 @@ module Bunny
     # @see http://rubybunny.info/articles/queues.html Queues and Consumers guide
     # @api public
     def ack(delivery_tag, multiple = false)
-      guarding_against_stale_delivery_tags(delivery_tag) do
-        basic_ack(delivery_tag.to_i, multiple)
-      end
+      basic_ack(delivery_tag.to_i, multiple)
     end
     alias acknowledge ack
 
@@ -498,9 +494,7 @@ module Bunny
     # @see http://rubybunny.info/articles/queues.html Queues and Consumers guide
     # @api public
     def nack(delivery_tag, multiple = false, requeue = false)
-      guarding_against_stale_delivery_tags(delivery_tag) do
-        basic_nack(delivery_tag.to_i, multiple, requeue)
-      end
+      basic_nack(delivery_tag.to_i, multiple, requeue)
     end
 
     # @endgroup
@@ -708,10 +702,12 @@ module Bunny
     # @see http://rubybunny.info/articles/queues.html Queues and Consumers guide
     # @api public
     def basic_reject(delivery_tag, requeue = false)
-      raise_if_no_longer_open!
-      @connection.send_frame(AMQ::Protocol::Basic::Reject.encode(@id, delivery_tag, requeue))
+      guarding_against_stale_delivery_tags(delivery_tag) do
+        raise_if_no_longer_open!
+        @connection.send_frame(AMQ::Protocol::Basic::Reject.encode(@id, delivery_tag, requeue))
 
-      nil
+        nil
+      end
     end
 
     # Acknowledges a delivery (message).
@@ -754,10 +750,12 @@ module Bunny
     # @see http://rubybunny.info/articles/queues.html Queues and Consumers guide
     # @api public
     def basic_ack(delivery_tag, multiple = false)
-      raise_if_no_longer_open!
-      @connection.send_frame(AMQ::Protocol::Basic::Ack.encode(@id, delivery_tag, multiple))
+      guarding_against_stale_delivery_tags(delivery_tag) do
+        raise_if_no_longer_open!
+        @connection.send_frame(AMQ::Protocol::Basic::Ack.encode(@id, delivery_tag, multiple))
 
-      nil
+        nil
+      end
     end
 
     # Rejects or requeues messages just like {Bunny::Channel#basic_reject} but can do so
@@ -814,13 +812,15 @@ module Bunny
     # @see http://rubybunny.info/articles/extensions.html RabbitMQ Extensions guide
     # @api public
     def basic_nack(delivery_tag, multiple = false, requeue = false)
-      raise_if_no_longer_open!
-      @connection.send_frame(AMQ::Protocol::Basic::Nack.encode(@id,
-          delivery_tag,
-          multiple,
-          requeue))
+      guarding_against_stale_delivery_tags(delivery_tag) do
+        raise_if_no_longer_open!
+        @connection.send_frame(AMQ::Protocol::Basic::Nack.encode(@id,
+                                                                 delivery_tag,
+                                                                 multiple,
+                                                                 requeue))
 
-      nil
+        nil
+      end
     end
 
     # Registers a consumer for queue. Delivered messages will be handled with the block

--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -753,7 +753,7 @@ module Bunny
     #
     # @see http://rubybunny.info/articles/queues.html Queues and Consumers guide
     # @api public
-    def basic_ack(delivery_tag, multiple)
+    def basic_ack(delivery_tag, multiple = false)
       raise_if_no_longer_open!
       @connection.send_frame(AMQ::Protocol::Basic::Ack.encode(@id, delivery_tag, multiple))
 

--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -707,7 +707,7 @@ module Bunny
     # @see Bunny::Channel#basic_nack
     # @see http://rubybunny.info/articles/queues.html Queues and Consumers guide
     # @api public
-    def basic_reject(delivery_tag, requeue)
+    def basic_reject(delivery_tag, requeue = false)
       raise_if_no_longer_open!
       @connection.send_frame(AMQ::Protocol::Basic::Reject.encode(@id, delivery_tag, requeue))
 

--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -752,7 +752,6 @@ module Bunny
     #   ch.basic_ack(delivery_info.delivery_tag.to_i, true)
     #
     # @see http://rubybunny.info/articles/queues.html Queues and Consumers guide
-    # @see #basic_ack_known_delivery_tag
     # @api public
     def basic_ack(delivery_tag, multiple)
       raise_if_no_longer_open!

--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -727,7 +727,7 @@ module Bunny
     #   ch    = conn.create_channel
     #   q.subscribe do |delivery_info, properties, payload|
     #     # requeue the message
-    #     ch.basic_ack(delivery_info.delivery_tag)
+    #     ch.basic_ack(delivery_info.delivery_tag.to_i)
     #   end
     #
     # @example Ack a message fetched via basic.get
@@ -737,7 +737,7 @@ module Bunny
     #   ch    = conn.create_channel
     #   # we assume the queue exists and has messages
     #   delivery_info, properties, payload = ch.basic_get("bunny.examples.queue3", :manual_ack => true)
-    #   ch.basic_ack(delivery_info.delivery_tag)
+    #   ch.basic_ack(delivery_info.delivery_tag.to_i)
     #
     # @example Ack multiple messages fetched via basic.get
     #   conn  = Bunny.new
@@ -749,7 +749,7 @@ module Bunny
     #   _, _, payload2 = ch.basic_get("bunny.examples.queue3", :manual_ack => true)
     #   delivery_info, properties, payload3 = ch.basic_get("bunny.examples.queue3", :manual_ack => true)
     #   # ack all fetched messages up to payload3
-    #   ch.basic_ack(delivery_info.delivery_tag, true)
+    #   ch.basic_ack(delivery_info.delivery_tag.to_i, true)
     #
     # @see http://rubybunny.info/articles/queues.html Queues and Consumers guide
     # @see #basic_ack_known_delivery_tag

--- a/spec/higher_level_api/integration/basic_ack_spec.rb
+++ b/spec/higher_level_api/integration/basic_ack_spec.rb
@@ -23,8 +23,11 @@ describe Bunny::Channel, "#ack" do
       delivery_details, properties, content = q.pop(:manual_ack => true)
 
       ch.ack(delivery_details.delivery_tag, true)
-      expect(q.message_count).to eq 0
+      ch.close
 
+      ch = connection.create_channel
+      q  = ch.queue("bunny.basic.ack.manual-acks", :exclusive => true)
+      expect(q.message_count).to eq 0
       ch.close
     end
   end
@@ -90,8 +93,11 @@ describe Bunny::Channel, "#ack" do
       $stderr = orig_stderr
 
       ch.ack(delivery_details.delivery_tag, true)
-      expect(q.message_count).to eq 0
+      ch.close
 
+      ch = connection.create_channel
+      q  = ch.queue("bunny.basic.ack.manual-acks", :exclusive => true)
+      expect(q.message_count).to eq 0
       ch.close
     end
   end

--- a/spec/higher_level_api/integration/basic_nack_spec.rb
+++ b/spec/higher_level_api/integration/basic_nack_spec.rb
@@ -27,9 +27,12 @@ describe Bunny::Channel, "#nack" do
 
       subject.nack(delivery_info.delivery_tag, false, false)
       sleep(0.5)
-      expect(q.message_count).to eq 0
-
       subject.close
+
+      ch = connection.create_channel
+      q = ch.queue("bunny.basic.nack.with-requeue-false", :exclusive => true)
+      expect(q.message_count).to eq 0
+      ch.close
     end
   end
 

--- a/spec/higher_level_api/integration/basic_reject_spec.rb
+++ b/spec/higher_level_api/integration/basic_reject_spec.rb
@@ -43,8 +43,11 @@ describe Bunny::Channel, "#reject" do
 
       ch.reject(delivery_info.delivery_tag, false)
       sleep(0.5)
-      expect(q.message_count).to eq 0
+      ch.close
 
+      ch = connection.create_channel
+      q  = ch.queue("bunny.basic.reject.with-requeue-false", :exclusive => true)
+      expect(q.message_count).to eq 0
       ch.close
     end
   end

--- a/spec/higher_level_api/integration/basic_reject_spec.rb
+++ b/spec/higher_level_api/integration/basic_reject_spec.rb
@@ -75,3 +75,56 @@ describe Bunny::Channel, "#reject" do
     end
   end
 end
+
+describe Bunny::Channel, "#basic_reject" do
+  let(:connection) do
+    c = Bunny.new(:user => "bunny_gem", :password => "bunny_password", :vhost => "bunny_testbed")
+    c.start
+    c
+  end
+
+  after :each do
+    connection.close if connection.open?
+  end
+
+  context "with requeue = true" do
+    it "requeues a message" do
+      ch = connection.create_channel
+      q  = ch.queue("bunny.basic.reject.manual-acks", :exclusive => true)
+      x  = ch.default_exchange
+
+      x.publish("bunneth", :routing_key => q.name)
+      sleep(0.5)
+      expect(q.message_count).to eq 1
+      delivery_info, _, _ = q.pop(:manual_ack => true)
+
+      ch.basic_reject(delivery_info.delivery_tag.to_i, true)
+      sleep(0.5)
+      expect(q.message_count).to eq 1
+
+      ch.close
+    end
+  end
+
+  context "with requeue = false" do
+    it "rejects a message" do
+      ch = connection.create_channel
+      q  = ch.queue("bunny.basic.reject.with-requeue-false", :exclusive => true)
+      x  = ch.default_exchange
+
+      x.publish("bunneth", :routing_key => q.name)
+      sleep(0.5)
+      expect(q.message_count).to eq 1
+      delivery_info, _, _ = q.pop(:manual_ack => true)
+
+      ch.basic_reject(delivery_info.delivery_tag.to_i, false)
+      sleep(0.5)
+      ch.close
+
+      ch = connection.create_channel
+      q  = ch.queue("bunny.basic.reject.with-requeue-false", :exclusive => true)
+      expect(q.message_count).to eq 0
+      ch.close
+    end
+  end
+end

--- a/spec/higher_level_api/integration/basic_reject_spec.rb
+++ b/spec/higher_level_api/integration/basic_reject_spec.rb
@@ -127,4 +127,26 @@ describe Bunny::Channel, "#basic_reject" do
       ch.close
     end
   end
+
+  context "with requeue = default" do
+    it "rejects a message" do
+      ch = connection.create_channel
+      q  = ch.queue("bunny.basic.reject.with-requeue-false", :exclusive => true)
+      x  = ch.default_exchange
+
+      x.publish("bunneth", :routing_key => q.name)
+      sleep(0.5)
+      expect(q.message_count).to eq 1
+      delivery_info, _, _ = q.pop(:manual_ack => true)
+
+      ch.basic_reject(delivery_info.delivery_tag.to_i)
+      sleep(0.5)
+      ch.close
+
+      ch = connection.create_channel
+      q  = ch.queue("bunny.basic.reject.with-requeue-false", :exclusive => true)
+      expect(q.message_count).to eq 0
+      ch.close
+    end
+  end
 end


### PR DESCRIPTION
Changes to Channel#basic_ack, #basic_nak, and #basic_reject:

* Protect against stale delivery tags
* Same defaults as the non-basic methods
* Minor rdoc corrections
* Tests detect more failures

See: #312