### PR TITLE
Use non blocking socket write for publishing messages

### DIFF
--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -564,7 +564,7 @@ module Bunny
         opts[:mandatory],
         false,
         @connection.frame_max)
-      @connection.send_frameset_without_timeout(frames, self)
+      @connection.send_frameset(frames, self)
 
       self
     end


### PR DESCRIPTION
Uses `@socket.write_nonblock_fully` by default when publishing messages through `basic_publish`.

As I mentioned [in the mailing list](https://groups.google.com/d/msg/ruby-amqp/OCEMGHfzCX4/FupfJUkEwa4J) I'm not sure if there should be more tests around this change. All existing tests pass with `CI=true`.