### PR TITLE
Add :recovery_attempts option to the connection

### DIFF
--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -673,7 +673,7 @@ module Bunny
 
     # @private
     def should_retry_recovery?
-      @recovery_attempts.nil? || @recovery_attempts > 0
+      @recovery_attempts.nil? || @recovery_attempts > 1
     end
 
     # @private

--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -113,6 +113,8 @@ module Bunny
     # @option connection_string_or_opts [IO, String] :log_file The file or path to use when creating a logger.  Defaults to STDOUT.
     # @option connection_string_or_opts [IO, String] :logfile DEPRECATED: use :log_file instead.  The file or path to use when creating a logger.  Defaults to STDOUT.
     # @option connection_string_or_opts [Integer] :log_level The log level to use when creating a logger.  Defaults to LOGGER::WARN
+    # @option connection_string_or_opts [Boolean] :automatically_recover Should automatically recover from network failures?
+    # @option connection_string_or_opts [Integer] :recovery_attempts Max number of recovery attempts
     #
     # @option optz [String] :auth_mechanism ("PLAIN") Authentication mechanism, PLAIN or EXTERNAL
     # @option optz [String] :locale ("PLAIN") Locale RabbitMQ should use
@@ -152,6 +154,7 @@ module Bunny
                                else
                                  opts[:automatically_recover] || opts[:automatic_recovery]
                                end
+      @recovery_attempts     = opts[:recovery_attempts]
       @network_recovery_interval = opts.fetch(:network_recovery_interval, DEFAULT_NETWORK_RECOVERY_INTERVAL)
       @recover_from_connection_close = opts.fetch(:recover_from_connection_close, false)
       # in ms
@@ -661,8 +664,16 @@ module Bunny
       rescue TCPConnectionFailedForAllHosts, TCPConnectionFailed, AMQ::Protocol::EmptyResponseError => e
         @logger.warn "TCP connection failed, reconnecting in #{@network_recovery_interval} seconds"
         sleep @network_recovery_interval
-        retry if recoverable_network_failure?(e)
+        if should_retry_recovery?
+          @recovery_attempts -= 1 if @recovery_attempts
+          retry if recoverable_network_failure?(e)
+        end
       end
+    end
+
+    # @private
+    def should_retry_recovery?
+      @recovery_attempts.nil? || @recovery_attempts > 0
     end
 
     # @private

--- a/spec/higher_level_api/integration/connection_recovery_spec.rb
+++ b/spec/higher_level_api/integration/connection_recovery_spec.rb
@@ -365,7 +365,7 @@ unless ENV["CI"]
     end
 
     it "tries to recover for a given number of attempts" do
-      with_recovery_attempts_limited_to(1) do |c|
+      with_recovery_attempts_limited_to(2) do |c|
         close_all_connections!
         expect(c).to receive(:start).exactly(2).times.and_raise(Bunny::TCPConnectionFailed.new("test"))
 


### PR DESCRIPTION
`:recovery_attempts` options sets the maximum number of attempts Bunny
would make to recover from network failures before giving up. `:recovery_attempts` is effective only
if `:automatically_recover` option is true.

I'm not sure if I handle the number of recovery attempts here correctly. E.g. if `:recovery_attempts => 1` Bunny would actually try to recover *twice* - once initially and once in the `rescue` block. Should it be this way or does it look like an off-by-one error?

Re tests: I had to resort to mocking even though I see Bunny test suite doesn't do it much. I couldn't come up with a better way to test it in a more "integration" fashion. Any suggestions?