### PR TITLE
Prefetch

### DIFF
--- a/spec/higher_level_api/integration/basic_qos_spec.rb
+++ b/spec/higher_level_api/integration/basic_qos_spec.rb
@@ -14,7 +14,20 @@ describe Bunny::Channel, "#prefetch" do
   context "with a positive integer < 65535" do
     it "sets that prefetch level via basic.qos" do
       ch = connection.create_channel
+      expect(ch.prefetch_count).not_to eq 10
+      expect(ch.prefetch_global).to be_nil
       expect(ch.prefetch(10)).to be_instance_of(AMQ::Protocol::Basic::QosOk)
+      expect(ch.prefetch_count).to eq 10
+      expect(ch.prefetch_global).to be false
+    end
+
+    it "sets that prefetch global via basic.qos" do
+      ch = connection.create_channel
+      expect(ch.prefetch_count).not_to eq 42
+      expect(ch.prefetch_global).to be_nil
+      expect(ch.prefetch(42, true)).to be_instance_of(AMQ::Protocol::Basic::QosOk)
+      expect(ch.prefetch_count).to eq 42
+      expect(ch.prefetch_global).to be true
     end
   end
 

--- a/spec/higher_level_api/integration/connection_recovery_spec.rb
+++ b/spec/higher_level_api/integration/connection_recovery_spec.rb
@@ -172,6 +172,7 @@ unless ENV["CI"]
         ch = c.create_channel
         ch.prefetch(11)
         expect(ch.prefetch_count).to eq 11
+        expect(ch.prefetch_global).to be false
         close_all_connections!
         sleep 0.1
         expect(c).not_to be_open
@@ -179,9 +180,26 @@ unless ENV["CI"]
         wait_for_recovery
         expect(ch).to be_open
         expect(ch.prefetch_count).to eq 11
+        expect(ch.prefetch_global).to be false
       end
     end
 
+    it "recovers basic.qos prefetch global setting" do
+      with_open do |c|
+        ch = c.create_channel
+        ch.prefetch(42, true)
+        expect(ch.prefetch_count).to eq 42
+        expect(ch.prefetch_global).to be true
+        close_all_connections!
+        sleep 0.1
+        expect(c).not_to be_open
+
+        wait_for_recovery
+        expect(ch).to be_open
+        expect(ch.prefetch_count).to eq 42
+        expect(ch.prefetch_global).to be true
+      end
+    end
 
     it "recovers publisher confirms setting" do
       with_open do |c|


### PR DESCRIPTION
The code and documentation related to RabbitMQ `prefetch` `global` appears to be incorrect for recent versions of RabbitMQ, in that it is actually supported (https://www.rabbitmq.com/consumer-prefetch.html). These patches extend the already-present references to `global`, surfacing it through `#prefetch`, keeping the same defaults as before, and updating the documentation to describe the current behaviour.

Although I haven't changed it in these patches, I also wonder about the clarity of the wording with regards to prefetch behaviour:

    Channel Qos (Prefetch Level)
    It is possible to control how many messages at most a consumer will be given (before it acknowledges or rejects previously consumed ones). This setting is per channel and controlled via #prefetch.
    (http://reference.rubybunny.info/Bunny/Channel.html)

Although it is indeed set per-channel as such, until I looked into what was actually happening, I've always interpreted this as meaning that the prefetch limit applies across the whole channel—that is, that setting `prefetch=10` and having multiple consumers will result in those consumers all sharing the same limit. But I see the default `global` Bunny sets is `false`, which actually applies the limit individually for each consumer, rather than `true`, which shares the limit (https://www.rabbitmq.com/consumer-prefetch.html). I haven't updated this wording, though, because I'm not convinced it isn't just me who got confused. :)

Peace,
tiredpixel