### PR TITLE
Fix socket inheritance for jruby

### DIFF
--- a/lib/bunny/jruby/socket.rb
+++ b/lib/bunny/jruby/socket.rb
@@ -5,7 +5,8 @@ module Bunny
     # TCP socket extension that uses Socket#readpartial to avoid excessive CPU
     # burn after some time. See issue #165.
     # @private
-    class Socket < Bunny::Socket
+    module Socket
+      include Bunny::Socket
 
       # Reads given number of bytes with an optional timeout
       #


### PR DESCRIPTION
Hi,

I was getting errors when trying to boot my application under jruby. I think the regression was introduced in https://github.com/ruby-amqp/bunny/commit/825f12998f3c5976af1a7528e5216f180b1ecf16

This PR fixes it. I could not run the specs successfully under jruby, but it seems they never ran successfully in the near past (I looked over travis-ci build before that commit).

```
! Unable to load application: TypeError: superclass must be a Class (#<Class:Bunny::Socket> given)
TypeError: superclass must be a Class (#<Class:Bunny::Socket> given)
    <module:JRuby> at /opt/boxen/rbenv/versions/jruby-9.0.0.0/lib/ruby/gems/shared/gems/bunny-2.0.0/lib/bunny/jruby/socket.rb:8
    <module:Bunny> at /opt/boxen/rbenv/versions/jruby-9.0.0.0/lib/ruby/gems/shared/gems/bunny-2.0.0/lib/bunny/jruby/socket.rb:4
             <top> at /opt/boxen/rbenv/versions/jruby-9.0.0.0/lib/ruby/gems/shared/gems/bunny-2.0.0/lib/bunny/jruby/socket.rb:3
           require at org/jruby/RubyKernel.java:940
```