### PR TITLE
Fix pause for default consumer thread pool  

### DIFF
--- a/lib/bunny/consumer_work_pool.rb
+++ b/lib/bunny/consumer_work_pool.rb
@@ -19,6 +19,7 @@ module Bunny
     def initialize(size = 1)
       @size  = size
       @queue = ::Queue.new
+      @paused = false
     end
 
 
@@ -57,12 +58,12 @@ module Bunny
 
     def pause
       @running = false
-
-      @threads.each { |t| t.stop }
+      @paused = true
     end
 
     def resume
       @running = true
+      @paused = false
 
       @threads.each { |t| t.run }
     end
@@ -78,6 +79,7 @@ module Bunny
     def run_loop
       catch(:terminate) do
         loop do
+          Thread.stop if @paused
           callable = @queue.pop
 
           begin


### PR DESCRIPTION
The Thread.stop is not an object method and operates in the context of the current thread. You cannot use this to pause and unpause the thread in this way. This commit resolves this by using a flag and check this at the beginning of every loop iteration.