### PR TITLE
Fix pause for default consumer thread pool (backport to 1.7.x-stable)

### DIFF
--- a/lib/bunny/consumer_work_pool.rb
+++ b/lib/bunny/consumer_work_pool.rb
@@ -19,6 +19,7 @@ module Bunny
     def initialize(size = 1)
       @size  = size
       @queue = ::Queue.new
+      @paused = false
     end
 
 
@@ -57,12 +58,12 @@ module Bunny
 
     def pause
       @running = false
-
-      @threads.each { |t| t.stop }
+      @paused = true
     end
 
     def resume
       @running = true
+      @paused = false
 
       @threads.each { |t| t.run }
     end
@@ -78,6 +79,7 @@ module Bunny
     def run_loop
       catch(:terminate) do
         loop do
+          Thread.stop if @paused
           callable = @queue.pop
 
           begin


### PR DESCRIPTION
PR for the 1.7.x stable branch as requested by @michaelklishin 