### PR TITLE
Get state of work pool more accurately 

### DIFF
--- a/lib/bunny/consumer_work_pool.rb
+++ b/lib/bunny/consumer_work_pool.rb
@@ -42,6 +42,14 @@ module Bunny
       @running
     end
 
+    def backlog
+      @queue.length
+    end
+
+    def busy?
+      !@queue.empty?
+    end
+
     def shutdown
       @running = false
 


### PR DESCRIPTION
Add a way to fetch actual state of queue. The running method does not provide you with the state of the actual processing happens and simply indicates if the pool has not been paused or killed

This commit introduces 2 methods that exposes relevant part of the internal queue datastructue without making it public using attr_<methods>. the are namely  a) Backlog b) Busy? both these can be used for cleaner shutdown mechanisms (the channle close causes unclen shutdowns as threads are really still active), and making decisions for dynamic scaling workers using queue "backpressure"