### PR TITLE
Fix for reliable shutdowns of ConsumerWorkPool

### DIFF
--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -165,7 +165,7 @@ module Bunny
     # @param [Bunny::Session] connection AMQP 0.9.1 connection
     # @param [Integer] id Channel id, pass nil to make Bunny automatically allocate it
     # @param [Bunny::ConsumerWorkPool] work_pool Thread pool for delivery processing, by default of size 1
-    def initialize(connection = nil, id = nil, work_pool = ConsumerWorkPool.new(1))
+    def initialize(connection = nil, id = nil, work_pool = ConsumerWorkPool.new(1,10))
       @connection = connection
       @logger     = connection.logger
       @id         = id || @connection.next_channel_id
@@ -230,10 +230,10 @@ module Bunny
     # {Bunny::Queue}, {Bunny::Exchange} and {Bunny::Consumer} instances.
     # @api public
     def close
-      @connection.close_channel(self)
-      @status = :closed
       @work_pool.shutdown
       maybe_kill_consumer_work_pool!
+      @connection.close_channel(self)
+      @status = :closed
     end
 
     # @return [Boolean] true if this channel is open, false otherwise

--- a/lib/bunny/consumer_work_pool.rb
+++ b/lib/bunny/consumer_work_pool.rb
@@ -22,8 +22,8 @@ module Bunny
       @paused = false
       # Attributes to handle clean reliable shutdown of the workpool
       @shutdown_timeout = shutdown_timeout
-      @shutdown_mutex = Mutex.new
-      @shutdown_conditional = ConditionalVariable.new
+      @shutdown_mutex = ::Mutex.new
+      @shutdown_conditional = ::ConditionalVariable.new
     end
 
 

--- a/lib/bunny/consumer_work_pool.rb
+++ b/lib/bunny/consumer_work_pool.rb
@@ -23,7 +23,7 @@ module Bunny
       # Attributes to handle clean reliable shutdown of the workpool
       @shutdown_timeout = shutdown_timeout
       @shutdown_mutex = ::Mutex.new
-      @shutdown_conditional = ::ConditionalVariable.new
+      @shutdown_conditional = ::ConditionVariable.new
     end
 
 

--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -329,14 +329,14 @@ module Bunny
     # opened (this operation is very fast and inexpensive).
     #
     # @return [Bunny::Channel] Newly opened channel
-    def create_channel(n = nil, consumer_pool_size = 1)
+    def create_channel(n = nil, consumer_pool_size = 1, consumer_shutdown_timeout = 10)
       raise ArgumentError, "channel number 0 is reserved in the protocol and cannot be used" if 0 == n
 
       @channel_mutex.synchronize do
         if n && (ch = @channels[n])
           ch
         else
-          ch = Bunny::Channel.new(self, n, ConsumerWorkPool.new(consumer_pool_size || 1))
+          ch = Bunny::Channel.new(self, n, ConsumerWorkPool.new(consumer_pool_size || 1, consumer_shutdown_timeout || 10))
           ch.open
           ch
         end


### PR DESCRIPTION
Make the shutdown mechanism for the default ConsumerWorkPool more reliable. The shutdown uses a combination of a Mutex and a ConditionalVariable with a sane default timeout (10s). One can optionally specify a per-channel "shutdown timeout" to configure this. The reordering of statements in the channel.close method ensures a shutdown of executing tasks (and perhaps forcefully killing the pool) before killing the connection , thereby eliminating in-deterministic state of the shutdown of consumer procs int the worker thread pool

@michaelklishin  based on our earlier discussions this seems like a reliable way to achieve the same effect without relying on self-pipes, I used the ConditionalVariable primitive and mutex to achieve the same effect as the continuation_queue(which seemed like an overkill). This is the optimal solution IMHO
