### PR TITLE
queue.delete never throws not-found with recent RabbitMQ versions

### DIFF
--- a/examples/connection/channel_level_exception.rb
+++ b/examples/connection/channel_level_exception.rb
@@ -12,14 +12,6 @@ conn = Bunny.new(:heartbeat_interval => 8)
 conn.start
 
 begin
-  ch1 = conn.create_channel
-  ch1.queue_delete("queue_that_should_not_exist#{rand}")
-rescue Bunny::NotFound => e
-  puts "Channel-level exception! Code: #{e.channel_close.reply_code}, message: #{e.channel_close.reply_text}"
-end
-
-
-begin
   ch2 = conn.create_channel
   q   = "bunny.examples.recovery.q#{rand}"
 


### PR DESCRIPTION
Since version 3.2 `exchange.delete`, `exchange.unbind`,
`queue.delete`, and `queue.unbind` never throw `not-found`
More on topic:
* http://lists.rabbitmq.com/pipermail/rabbitmq-discuss/2014-January/032970.html
* http://www.rabbitmq.com/specification.html

Probably other examples/tests should be updated as well