### PR TITLE
Check for ::Exception instead of Bunny::Exception when trying to get an error's message

### DIFF
--- a/lib/bunny/exceptions.rb
+++ b/lib/bunny/exceptions.rb
@@ -69,7 +69,7 @@ module Bunny
       m = case e
           when String then
             e
-          when Exception then
+          when ::Exception then
             e.message
           end
       if hostname && port


### PR DESCRIPTION
On https://github.com/ruby-amqp/bunny/blob/master/lib/bunny/exceptions.rb#L72, Bunny tries to get error messages from all ```Exception```s by checking if the passed in error is a ```Exception```. However, this references ```Bunny::Exception```, not ```::Exception```. Not sure if this was really intended, but it's a bit confusing cause real errors like ```NoMethodError``` during connecting never show up due to this.

For example, running Bunny inside JRuby explodes (due to another issue, see below) but the error message never appears:

```
$ java -version
java version "1.8.0_60"
Java(TM) SE Runtime Environment (build 1.8.0_60-b27)
Java HotSpot(TM) 64-Bit Server VM (build 25.60-b23, mixed mode)

$ rvm use jruby-9.0.1.0

$ bundle list
Gems included by the bundle:
  * amq-protocol (2.0.0)
  * bundler (1.10.6)
  * bunny (2.2.0)

$ ruby -e 'require "bunny"; Bunny.new.start'
W, [2015-10-08T10:18:49.731000 #13626]  WARN -- #<Bunny::Session:0xfa4 guest@127.0.0.1:5672, vhost=/, addresses=[127.0.0.1:5672]>: Could not establish TCP connection to 127.0.0.1:5672: 
Bunny::TCPConnectionFailedForAllHosts: Could not establish TCP connection to any of the configured hosts
  start at /home/buecker/.rvm/gems/jruby-9.0.1.0/gems/bunny-2.2.0/lib/bunny/session.rb:315
  <top> at -e:1
```

The real error here isn't a connection error but a ```NoMethodError``` due to the way Bunny::JRuby::Socket includes code from Bunny::CRuby::Socket (I'll open a different issue for that and link it here): ```private method `open' called for Bunny::JRuby::Socket:Module```. Checking for ```::Exception``` reveals this:

```
$ ruby -e 'require "bunny"; Bunny.new.start'
W, [2015-10-08T10:26:16.456000 #16364]  WARN -- #<Bunny::Session:0xfa4 guest@127.0.0.1:5672, vhost=/, addresses=[127.0.0.1:5672]>: Could not establish TCP connection to 127.0.0.1:5672: private method `open' called for Bunny::JRuby::Socket:Module
Bunny::TCPConnectionFailedForAllHosts: Could not establish TCP connection to any of the configured hosts
  start at /home/buecker/.rvm/gems/jruby-9.0.1.0/gems/bunny-2.2.0/lib/bunny/session.rb:315
  <top> at ./works.rb:7
```

With this PR, the proper error message is printed.