### PR TITLE
Adds explicit `$host` param to the `before_build` script

### DIFF
--- a/bin/ci/before_build
+++ b/bin/ci/before_build
@@ -1,11 +1,12 @@
 #!/usr/bin/env ruby
 
 $nodename = ENV.fetch("RABBITMQ_NODENAME", "rabbit")
+$host     = ENV.fetch("RABBITMQ_HOST", "localhost")
 $ctl      = ENV.fetch("RABBITMQCTL",       "sudo rabbitmqctl")
 $plugins  = ENV.fetch("RABBITMQ_PLUGINS",  "sudo rabbitmq-plugins")
 
 def rabbit_control(args)
-  command = "#{$ctl} -n #{$nodename} #{args}"
+  command = "#{$ctl} -n #{$nodename}@#{$host} #{args}"
   system command
 end
 


### PR DESCRIPTION
Setting a host explicitly helps to avoid the problem when rabbitmqctl
resolves host name as a machine name (e.g. Bob's iMac) but then can't
connect to the cluster using this name. For some reason rabbitmqctl can
successfully connect to the localhost cluster only if the name of the cluster
is "rabbit@localhost" rather than "rabbit@Bob's iMac".

I've had this problem when running `before_build` on several machines. I'm not entirely sure it's not due to the idiosyncrasies of my RabbitMQ configuration so please feel free to ignore!

