### PR TITLE
A test in Bunny::Queue doesn't specify expectation.

### DIFF
--- a/spec/higher_level_api/integration/basic_consume_spec.rb
+++ b/spec/higher_level_api/integration/basic_consume_spec.rb
@@ -260,7 +260,10 @@ describe Bunny::Queue, "#subscribe" do
       let(:queue_name) { "bunny.basic_consume#{rand}" }
 
       it "uses exception handler" do
+        caughts = []
         t = Thread.new do
+          allow(connection.logger).to receive(:error) { |x| caughts << x }
+
           ch = connection.create_channel
           q  = ch.queue(queue_name, :auto_delete => true, :durable => false)
 
@@ -275,6 +278,8 @@ describe Bunny::Queue, "#subscribe" do
         x  = ch.default_exchange
         5.times { x.publish("hello", :routing_key => queue_name) }
         sleep 1.5
+
+        expect(caughts.size).to eq(5)
 
         ch.close
       end


### PR DESCRIPTION
Hi, I report a trivial PR.

There is no matcher processing in a test suite of 'and default exception handler' which is written in `spec/higher_level_api/integration/basic_consume_spec.rb`.
I think this checks default exception handler, logger.error, is called when some `RuntimeError` is raised at `subscribe` block.

So I added a matcher processing to checks avobe. 
According to this, the test suite checks the behavior that default exception handler is called when `RuntimeError` is occurred.