### PR TITLE
Fix the problem that rspec fails on Travis CI

### DIFF
--- a/bin/ci/before_build
+++ b/bin/ci/before_build
@@ -1,11 +1,10 @@
 #!/usr/bin/env ruby
 
-$nodename = ENV.fetch("RABBITMQ_NODENAME", "rabbit")
 $ctl      = ENV.fetch("RABBITMQCTL",       "sudo rabbitmqctl")
 $plugins  = ENV.fetch("RABBITMQ_PLUGINS",  "sudo rabbitmq-plugins")
 
 def rabbit_control(args)
-  command = "#{$ctl} -n #{$nodename} #{args}"
+  command = "#{$ctl} #{args}"
   system command
 end
 


### PR DESCRIPTION
Hi, I'm trying to address the problem that rspec fails on Travis CI.
This is because the failure of registering RabbitMQ user/permission by `bin/ci/before_build`.

The reason why this problem occurred is `-n` parameter of `rabbitmqctl` which is specified in that script.
Environment variable of `RABBITMQ_NODENAME=rabbit@localhost` is specified in `/etc/rabbitmq/rabbitmq-env.conf` which is generated by Travis.
Therefore, a failure of connection is happened.

To prevent it, I deleted this parameter. Because the most of integrated test suites refer to the server in localhsot.