### PR TITLE
Only evaluate strings for debug logging messages if required

### DIFF
--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -1488,7 +1488,7 @@ module Bunny
     #
     # @api plugin
     def recover_from_network_failure
-      @logger.debug "Recovering channel #{@id} after network failure"
+      @logger.debug { "Recovering channel #{@id} after network failure" }
       release_all_continuations
 
       recover_prefetch_setting
@@ -1544,7 +1544,7 @@ module Bunny
     # @api plugin
     def recover_queues
       @queues.values.dup.each do |q|
-        @logger.debug "Recovering queue #{q.name}"
+        @logger.debug { "Recovering queue #{q.name}" }
         q.recover_from_network_failure
       end
     end
@@ -1616,7 +1616,7 @@ module Bunny
 
     # @private
     def handle_method(method)
-      @logger.debug "Channel#handle_frame on channel #{@id}: #{method.inspect}"
+      @logger.debug { "Channel#handle_frame on channel #{@id}: #{method.inspect}" }
       case method
       when AMQ::Protocol::Queue::DeclareOk then
         @continuations.push(method)

--- a/lib/bunny/heartbeat_sender.rb
+++ b/lib/bunny/heartbeat_sender.rb
@@ -62,7 +62,7 @@ module Bunny
       now = Time.now
 
       if now > (@last_activity_time + @interval)
-        @logger.debug "Sending a heartbeat, last activity time: #{@last_activity_time}, interval (s): #{@interval}"
+        @logger.debug { "Sending a heartbeat, last activity time: #{@last_activity_time}, interval (s): #{@interval}" }
         @transport.write_without_timeout(AMQ::Protocol::HeartbeatFrame.encode)
       end
     end

--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -547,7 +547,7 @@ module Bunny
     #
     # @private
     def handle_frame(ch_number, method)
-      @logger.debug "Session#handle_frame on #{ch_number}: #{method.inspect}"
+      @logger.debug { "Session#handle_frame on #{ch_number}: #{method.inspect}" }
       case method
       when AMQ::Protocol::Channel::OpenOk then
         @continuations.push(method)
@@ -1049,7 +1049,7 @@ module Bunny
                               else
                                 negotiate_value(@client_heartbeat, connection_tune.heartbeat)
                               end
-      @logger.debug "Heartbeat interval negotiation: client = #{@client_heartbeat}, server = #{connection_tune.heartbeat}, result = #{@heartbeat}"
+      @logger.debug { "Heartbeat interval negotiation: client = #{@client_heartbeat}, server = #{connection_tune.heartbeat}, result = #{@heartbeat}" }
       @logger.info "Heartbeat interval used (in seconds): #{@heartbeat}"
 
       # We set the read_write_timeout to twice the heartbeat value
@@ -1069,9 +1069,9 @@ module Bunny
       end
 
       @transport.send_frame(AMQ::Protocol::Connection::TuneOk.encode(@channel_max, @frame_max, @heartbeat))
-      @logger.debug "Sent connection.tune-ok with heartbeat interval = #{@heartbeat}, frame_max = #{@frame_max}, channel_max = #{@channel_max}"
+      @logger.debug { "Sent connection.tune-ok with heartbeat interval = #{@heartbeat}, frame_max = #{@frame_max}, channel_max = #{@channel_max}" }
       @transport.send_frame(AMQ::Protocol::Connection::Open.encode(self.vhost))
-      @logger.debug "Sent connection.open with vhost = #{self.vhost}"
+      @logger.debug { "Sent connection.open with vhost = #{self.vhost}" }
 
       frame2 = begin
                  fr = @transport.read_next_frame

--- a/lib/bunny/transport.rb
+++ b/lib/bunny/transport.rb
@@ -458,8 +458,8 @@ but prone man-in-the-middle attacks. Please set :verify_peer => true in producti
           cert_inlines.push(cert)
         end
       end
-      @logger.debug "Using CA certificates at #{cert_files.join(', ')}"
-      @logger.debug "Using #{cert_inlines.count} inline CA certificates"
+      @logger.debug { "Using CA certificates at #{cert_files.join(', ')}" }
+      @logger.debug { "Using #{cert_inlines.count} inline CA certificates" }
       if certs.empty?
         @logger.error "No CA certificates found, add one with :tls_ca_certificates"
       end


### PR DESCRIPTION
Most of the times debug messages are not logged so it's a best practice to avoid evaluating strings that are used in debugging log messages unless they are required.