### PR TITLE
Fix repeated automatic recovery from network failures after restarting rabbitmq once

### DIFF
--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -636,6 +636,7 @@ module Bunny
             @channels.each do |n, ch|
               ch.maybe_kill_consumer_work_pool!
             end
+            @reader_loop.stop if @reader_loop
             maybe_shutdown_heartbeat_sender
 
             recover_from_network_failure


### PR DESCRIPTION
Fix Issue #376, by flagging `reader_loop` to stop before calling `recover_from_network_failure` to start another `reader_loop` thread.