### PR TITLE
Update comment to reflect code

### DIFF
--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -935,7 +935,7 @@ module Bunny
       end
     end
 
-    # Sends multiple frames, one by one. For thread safety this method takes a channel
+    # Sends multiple frames, in one go. For thread safety this method takes a channel
     # object and synchronizes on it.
     #
     # @private


### PR DESCRIPTION
It looks like the following commit makes the comment outdated:

https://github.com/ruby-amqp/bunny/commit/d35042a5

That is, we used to send frames one by one, but now pack them all into
one object ready for writing.