### PR TITLE
Consumer worker pool threads bubble up Exception instead of going zombie

### DIFF
--- a/lib/bunny/consumer_work_pool.rb
+++ b/lib/bunny/consumer_work_pool.rb
@@ -32,6 +32,7 @@ module Bunny
 
       @size.times do
         t = Thread.new(&method(:run_loop))
+        t.abort_on_exception = true
         @threads << t
       end
 


### PR DESCRIPTION
App developers who want to rescue from Exception should do that inside of their own worker code. This change makes sure that they realize that they are getting Exceptions in the first place.