### PR TITLE
Allow work pools that abort on Exception.

### DIFF
--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -1555,7 +1555,7 @@ module Bunny
     # @api plugin
     def recover_consumers
       unless @consumers.empty?
-        @work_pool = ConsumerWorkPool.new(@work_pool.size)
+        @work_pool = ConsumerWorkPool.new(@work_pool.size, @work_pool.abort_on_exception)
         @work_pool.start
       end
       @consumers.values.dup.each do |c|

--- a/lib/bunny/consumer_work_pool.rb
+++ b/lib/bunny/consumer_work_pool.rb
@@ -15,9 +15,11 @@ module Bunny
 
     attr_reader :threads
     attr_reader :size
+    attr_reader :abort_on_exception
 
-    def initialize(size = 1)
+    def initialize(size = 1, abort_on_exception = false)
       @size  = size
+      @abort_on_exception = abort_on_exception
       @queue = ::Queue.new
       @paused = false
     end
@@ -32,6 +34,7 @@ module Bunny
 
       @size.times do
         t = Thread.new(&method(:run_loop))
+        t.abort_on_exception = true if abort_on_exception
         @threads << t
       end
 

--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -331,14 +331,14 @@ module Bunny
     # opened (this operation is very fast and inexpensive).
     #
     # @return [Bunny::Channel] Newly opened channel
-    def create_channel(n = nil, consumer_pool_size = 1)
+    def create_channel(n = nil, consumer_pool_size = 1, consumer_pool_abort_on_exception = false)
       raise ArgumentError, "channel number 0 is reserved in the protocol and cannot be used" if 0 == n
 
       @channel_mutex.synchronize do
         if n && (ch = @channels[n])
           ch
         else
-          ch = Bunny::Channel.new(self, n, ConsumerWorkPool.new(consumer_pool_size || 1))
+          ch = Bunny::Channel.new(self, n, ConsumerWorkPool.new(consumer_pool_size || 1, consumer_pool_abort_on_exception))
           ch.open
           ch
         end


### PR DESCRIPTION
Some users may prefer the consumer work pool bubble up exceptions.