### PR TITLE
Remove unused ivar in Bunny::Queue

### DIFF
--- a/lib/bunny/queue.rb
+++ b/lib/bunny/queue.rb
@@ -37,7 +37,6 @@ module Bunny
       @channel          = channel
       @name             = name
       @options          = self.class.add_default_options(name, opts)
-      @consumers        = Hash.new
 
       @durable          = @options[:durable]
       @exclusive        = @options[:exclusive]


### PR DESCRIPTION
I'm assuming this isn't poked at from outside somehow. This confused me for a second whilst thinking about design of the iOS client.