### PR TITLE
Don't recover from network failures in Transport#read_fully

### DIFF
--- a/lib/bunny/reader_loop.rb
+++ b/lib/bunny/reader_loop.rb
@@ -33,7 +33,7 @@ module Bunny
         begin
           break if @mutex.synchronize { @stopping || @stopped || @network_is_down }
           run_once
-        rescue AMQ::Protocol::EmptyResponseError, IOError, SystemCallError => e
+        rescue AMQ::Protocol::EmptyResponseError, IOError, SystemCallError, Timeout::Error => e
           break if terminate? || @session.closing? || @session.closed?
 
           log_exception(e)

--- a/lib/bunny/transport.rb
+++ b/lib/bunny/transport.rb
@@ -218,7 +218,7 @@ module Bunny
         @status = :not_connected
 
         if @session.automatically_recover?
-          @session.handle_network_failure(e)
+          raise
         else
           @session_thread.raise(Bunny::NetworkFailure.new("detected a network failure: #{e.message}", e))
         end


### PR DESCRIPTION
Fixes #359 

When recovering from a network failure, `read_fully` returns the return value of the call to `@session.handle_network_failure(e)`.

https://github.com/ruby-amqp/bunny/blob/641088faaf1718b05bad2af5c65bbb925565848e/lib/bunny/transport.rb#L221

In some cases this is a `Hash` returned from here:
https://github.com/ruby-amqp/bunny/blob/641088faaf1718b05bad2af5c65bbb925565848e/lib/bunny/session.rb#L705

It makes sense to avoid recovering from network failures inside `Transport#read_fully` as the recovery code replaces the transport itself. The reader loop can catch the failure and do the recovery for us.