### PR TITLE
Don't recover from network failures in Transport#read_fully (backport to 1.7.x stable)

### DIFF
--- a/lib/bunny/reader_loop.rb
+++ b/lib/bunny/reader_loop.rb
@@ -33,7 +33,7 @@ module Bunny
         begin
           break if @mutex.synchronize { @stopping || @stopped || @network_is_down }
           run_once
-        rescue AMQ::Protocol::EmptyResponseError, IOError, SystemCallError => e
+        rescue AMQ::Protocol::EmptyResponseError, IOError, SystemCallError, Timeout::Error => e
           break if terminate? || @session.closing? || @session.closed?
 
           log_exception(e)

--- a/lib/bunny/transport.rb
+++ b/lib/bunny/transport.rb
@@ -218,7 +218,7 @@ module Bunny
         @status = :not_connected
 
         if @session.automatically_recover?
-          @session.handle_network_failure(e)
+          raise
         else
           @session_thread.raise(Bunny::NetworkFailure.new("detected a network failure: #{e.message}", e))
         end

--- a/spec/higher_level_api/integration/connection_stop_spec.rb
+++ b/spec/higher_level_api/integration/connection_stop_spec.rb
@@ -52,7 +52,7 @@ describe Bunny::Session do
 
   describe "that recovers from connection.close" do
     it "can be closed" do
-      c  = Bunny.new(:automatically_recover => false, :recover_from_connection_close => true, :network_recovery_interval => 0.2)
+      c  = Bunny.new(:automatically_recover => true, :recover_from_connection_close => true, :network_recovery_interval => 0.2)
       c.start
       ch = c.create_channel
 


### PR DESCRIPTION
Fixes https://github.com/ruby-amqp/bunny/issues/359 for 1.7.x-stable.

(cherry-picked commits from https://github.com/ruby-amqp/bunny/pull/387)