### PR TITLE
Only use RABBITMQ_URL when no argument is given

### DIFF
--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -125,12 +125,12 @@ module Bunny
     # @see http://rubybunny.info/articles/connecting.html Connecting to RabbitMQ guide
     # @see http://rubybunny.info/articles/tls.html TLS/SSL guide
     # @api public
-    def initialize(connection_string_or_opts = Hash.new, optz = Hash.new)
-      opts = case (ENV["RABBITMQ_URL"] || connection_string_or_opts)
+    def initialize(connection_string_or_opts = ENV['RABBITMQ_URL'], optz = Hash.new)
+      opts = case (connection_string_or_opts)
              when nil then
                Hash.new
              when String then
-               self.class.parse_uri(ENV["RABBITMQ_URL"] || connection_string_or_opts)
+               self.class.parse_uri(connection_string_or_opts)
              when Hash then
                connection_string_or_opts
              end.merge(optz)


### PR DESCRIPTION
Whenever `ENV['RABBITMQ_URL']` is present, Bunny seems to use this for its connection string regardless if there is a specific connection string given as argument.

This PR addresses this issue and now only considers `ENV['RABBITMQ_URL']` when no argument is given.

On my local setup (ubuntu 16.04, rabbitmq-server 3.5.7-1 and ruby 2.1.5) one of the specs is failing:
```
Bunny::Session
  can be closed
  can be closed twice (Session#close is idempotent)
  in a single threaded mode
    can be closed
  that recovers from connection.close
    can be closed (FAILED - 1)
```
both before and after I added my changes, so I'm going to take my chances and see if Travis can build this PR.