### PR TITLE
Fix issues with using the RABBITMQ_URL environment variable

### DIFF
--- a/lib/bunny.rb
+++ b/lib/bunny.rb
@@ -58,7 +58,7 @@ module Bunny
   # @see http://rubybunny.info/articles/getting_started.html
   # @see http://rubybunny.info/articles/connecting.html
   # @api public
-  def self.new(connection_string_or_opts = {}, opts = {}, &block)
+  def self.new(connection_string_or_opts = ENV['RABBITMQ_URL'], opts = {}, &block)
     if connection_string_or_opts.respond_to?(:keys) && opts.empty?
       opts = connection_string_or_opts
     end
@@ -70,7 +70,7 @@ module Bunny
   end
 
 
-  def self.run(connection_string_or_opts = {}, opts = {}, &block)
+  def self.run(connection_string_or_opts = ENV['RABBITMQ_URL'], opts = {}, &block)
     raise ArgumentError, 'Bunny#run requires a block' unless block
 
     client = Session.new(connection_string_or_opts, opts)

--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -125,12 +125,12 @@ module Bunny
     # @see http://rubybunny.info/articles/connecting.html Connecting to RabbitMQ guide
     # @see http://rubybunny.info/articles/tls.html TLS/SSL guide
     # @api public
-    def initialize(connection_string_or_opts = Hash.new, optz = Hash.new)
-      opts = case (ENV["RABBITMQ_URL"] || connection_string_or_opts)
+    def initialize(connection_string_or_opts = ENV['RABBITMQ_URL'], optz = Hash.new)
+      opts = case (connection_string_or_opts)
              when nil then
                Hash.new
              when String then
-               self.class.parse_uri(ENV["RABBITMQ_URL"] || connection_string_or_opts)
+               self.class.parse_uri(connection_string_or_opts)
              when Hash then
                connection_string_or_opts
              end.merge(optz)


### PR DESCRIPTION
I experienced some issues when trying to have two Bunny instances at the same time, where one would be instantiated using `Bunny.new` (with a connection string set in the RABBITMQ_URL environment variable) and the other would be instantiated using `Bunny.new(some_connection_string)`. Apparently both instances would then use the connection string from the RABBITMQ_URL environment variable.

This PR is a fix to that issue, so when a Bunny is instantiated given a specific connection string (or hash), it will disregard the RABBITMQ_URL environment variable and when Bunny is instantiated without a connection argument, it will default to use value of a look-up of the RABBITMQ_URL environment variable.