### PR TITLE
Add support for starting a RabbitMQ server using Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,14 +186,18 @@ contributing failing test cases.
 ### Running the Specs
 
 The specs require RabbitMQ to be running locally with a specific set of vhosts
-and users. RabbitMQ can be provisioned and started any that's convenient to you
+and users. RabbitMQ can be provisioned and started any way that's convenient to you
 as long as it has a suitable TLS keys configuration and management plugin enabled.
 Make sure you have a recent version of RabbitMQ (> `3.5.3`).
 
 You can also start a clean RabbitMQ server
 node on your machine specifically for the bunny specs.
-To do so, run the following command
-from the base directory of the gem:
+This can be done either by using a locally installed RabbitMQ server or by
+running a RabbitMQ server in a Docker container.
+
+#### Using a locally installed RabbitMQ server
+
+Run the following command from the base directory of the gem:
 
 ```
 RABBITMQ_NODENAME=bunny RABBITMQ_CONFIG_FILE=./spec/config/rabbitmq RABBITMQ_ENABLED_PLUGINS_FILE=./spec/config/enabled_plugins rabbitmq-server
@@ -213,6 +217,24 @@ And then run the core integration suite:
 RABBITMQ_NODENAME=bunny CI=true rspec
 ```
 
+#### Running a RabbitMQ server in a Docker container
+
+First off you have to install Docker (>= 1.9). See https://docs.docker.com/engine/installation/
+
+After Docker has been installed (and the `docker` command is available on your command line path), run
+
+    ./bin/ci/start_rabbitmq.sh
+
+The first time you do this, it will take some time, since it has to download everything it needs
+to build the Docker image.
+
+The RabbitMQ server will run in the foreground in the terminal where you started it. You can stop
+it by pressing CTRL+C.
+
+Now (in another terminal) run the specs:
+
+    CI=true rspec
+
 ## Other Ruby RabbitMQ Clients
 
 The other widely used Ruby RabbitMQ client is [March Hare](http://rubymarchhare.info) (JRuby-only).
@@ -225,11 +247,15 @@ First, clone the repository and run
 
     bundle install --binstubs
 
-then set up RabbitMQ vhosts with
+then either set up your locally installed RabbitMQ server vhosts with
 
     ./bin/ci/before_build
 
 (if needed, set `RABBITMQCTL` env variable to point to `rabbitmqctl` you want to use)
+
+or start a RabbitMQ server in a Docker container with (requires Docker - see https://docs.docker.com/engine/installation/)
+
+    ./bin/ci/start_rabbitmq.sh
 
 and then run tests with
 

--- a/bin/ci/start_rabbitmq.sh
+++ b/bin/ci/start_rabbitmq.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+if [ -z `which docker` ]; then
+  echo 'You need to install docker to run this script. See https://docs.docker.com/engine/installation/'
+  exit
+fi
+
+cd $(dirname $(readlink -f $0))
+docker build -t bunny_rabbitmq ../../docker && \
+exec docker run --net host -ti bunny_rabbitmq

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,14 @@
+FROM debian:jessie
+
+RUN apt-get -q update && \
+    apt-get install -yq --no-install-recommends wget ca-certificates
+
+RUN echo 'deb http://www.rabbitmq.com/debian/ testing main' > /etc/apt/sources.list.d/rabbitmq.list && \
+    wget -O- https://www.rabbitmq.com/rabbitmq-signing-key-public.asc | apt-key add -
+
+RUN apt-get -q update && \
+    apt-get install -yq --no-install-recommends rabbitmq-server
+
+COPY docker-entrypoint.sh /
+
+ENTRYPOINT /docker-entrypoint.sh

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+server=rabbitmq-server
+ctl=rabbitmqctl
+plugins=rabbitmq-plugins
+delay=3
+
+echo '[Configuration] Starting RabbitMQ in detached mode.'
+
+$server -detached
+
+echo "[Configuration] Waiting $delay seconds for RabbitMQ to start."
+
+sleep $delay
+
+echo '*** Enabling plugins ***'
+$plugins enable --online rabbitmq_management
+$plugins enable --online rabbitmq_consistent_hash_exchange
+
+echo '*** Creating users ***'
+$ctl add_user bunny_gem bunny_password
+$ctl add_user bunny_reader reader_password
+
+echo '*** Creating virtual hosts ***'
+$ctl add_vhost bunny_testbed
+
+echo '*** Setting virtual host permissions ***'
+$ctl set_permissions -p / guest '.*' '.*' '.*'
+$ctl set_permissions -p bunny_testbed bunny_gem '.*' '.*' '.*'
+$ctl set_permissions -p bunny_testbed guest '.*' '.*' '.*'
+$ctl set_permissions -p bunny_testbed bunny_reader '^---$' '^---$' '.*'
+
+$ctl stop
+
+echo "[Configuration] Waiting $delay seconds for RabbitMQ to stop."
+
+sleep $delay
+
+echo 'Starting RabbitMQ in foreground (CTRL-C to exit)'
+
+exec $server


### PR DESCRIPTION
This PR is about convenience of starting the RabbitMQ server you need when running the specs and as such doesn't address any known issues.

Given Docker is installed on the local machine, I added supported for starting a Docker container with a running, provisioned RabbitMQ server. This eliminates the need to install RabbitMQ locally. I also updated the README with appropriate information on how to start the Docker container.

The Docker container is based on a clean debian jessie using the RabbitMQ PPA for installing the newest released version of RabbitMQ. Upon start, the RabbitMQ server is automatically provisioned with the plugins, users, vhosts and permissions required by the specs (see the `docker/docker-entrypoint.sh` file). All anyone wishing to contribute needs to do is run the `bin/ci/start_rabbitmq.sh` script.

- Add support for starting a (provisioned) RabbitMQ server in
  a Docker container for running the specs against.
- Update README with information on how to start the RabbitMQ
  server using Docker.