### PR TITLE
Convert socket to Celluloid::IO sockets when required

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :development do
   gem "ruby-prof", :platform => :mri
 
   gem "json",      :platform => :ruby_18
+  gem "celluloid"
   gem "celluloid-io"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :development do
   gem "ruby-prof", :platform => :mri
 
   gem "json",      :platform => :ruby_18
+  gem "celluloid-io"
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,9 @@ group :development do
   gem "ruby-prof", :platform => :mri
 
   gem "json",      :platform => :ruby_18
+end
+
+group :ci do
   gem "celluloid"
   gem "celluloid-io"
 end

--- a/lib/bunny/cruby/socket.rb
+++ b/lib/bunny/cruby/socket.rb
@@ -22,8 +22,8 @@ module Bunny
       socket.extend self
       socket.options = { :host => host, :port => port }.merge(options)
 
-      if defined? Celluloid::IO && Celluloid::IO.evented?
-        socket = Celluloid::IO::Socket.try_convert(socket)
+      if defined? ::Celluloid::IO && ::Celluloid::IO.evented?
+        socket = ::Celluloid::IO::Socket.try_convert(socket)
       end
 
       socket

--- a/lib/bunny/cruby/socket.rb
+++ b/lib/bunny/cruby/socket.rb
@@ -21,6 +21,11 @@ module Bunny
       socket.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_KEEPALIVE, true) if options.fetch(:keepalive, true)
       socket.extend self
       socket.options = { :host => host, :port => port }.merge(options)
+
+      if defined? Celluloid::IO && Celluloid::IO.evented?
+        socket = Celluloid::IO::Socket.try_convert(socket)
+      end
+
       socket
     rescue Errno::ETIMEDOUT
       raise ClientTimeout

--- a/lib/bunny/cruby/socket.rb
+++ b/lib/bunny/cruby/socket.rb
@@ -22,8 +22,8 @@ module Bunny
       socket.extend self
       socket.options = { :host => host, :port => port }.merge(options)
 
-      if defined? ::Celluloid::IO && ::Celluloid::IO.evented?
-        socket = ::Celluloid::IO::Socket.try_convert(socket)
+      if defined? ::Celluloid::IO
+        socket = ::Celluloid::IO::Socket.try_convert(socket) if ::Celluloid::IO.evented?
       end
 
       socket

--- a/spec/higher_level_api/integration/celluloid_io_integration_spec.rb
+++ b/spec/higher_level_api/integration/celluloid_io_integration_spec.rb
@@ -1,4 +1,3 @@
-require 'celluloid/current'
 require 'celluloid/test'
 require 'celluloid/io'
 require 'spec_helper'

--- a/spec/higher_level_api/integration/celluloid_io_integration_spec.rb
+++ b/spec/higher_level_api/integration/celluloid_io_integration_spec.rb
@@ -1,119 +1,124 @@
-require 'celluloid/test'
-require 'celluloid/io'
-require 'spec_helper'
+begin
+  require 'celluloid/current'
+  require 'celluloid/test'
+  require 'celluloid/io'
+  require 'spec_helper'
 
-class RabbitMQActor
-  include Celluloid::IO
+  class RabbitMQActor
+    include Celluloid::IO
 
-  attr_reader :c
+    attr_reader :c
 
-  def initialize
-    @c = Bunny.new(:user => "bunny_gem", :password => "bunny_password", :vhost => "bunny_testbed")
-    @c.start
+    def initialize
+      @c = Bunny.new(:user => "bunny_gem", :password => "bunny_password", :vhost => "bunny_testbed")
+      @c.start
+    end
+
+    def terminate
+      @c.stop
+      super
+    end
   end
 
-  def terminate
-    @c.stop
-    super
-  end
-end
-
-class RabbitMQSampleProducer < RabbitMQActor
-  def publish_basic
-    ch = @c.create_channel
-
-    q  = ch.queue("", :exclusive => true)
-    x  = ch.fanout("amq.fanout")
-    q.bind(x)
-
-    rk = "a" * 254
-    x.publish("xyzzy", :routing_key => rk, :persistent => true)
-
-    sleep(1)
-    message_count = q.message_count
-
-    _, _, payload = q.pop
-
-    ch.close
-
-    return message_count, payload
-  end
-end
-
-class RabbitMQSampleConsumer < RabbitMQActor
-  def consume_basic(queue_name)
-    delivered_keys = []
-    delivered_data = []
-
-    t = Thread.new do
+  class RabbitMQSampleProducer < RabbitMQActor
+    def publish_basic
       ch = @c.create_channel
-      q = ch.queue(queue_name, :auto_delete => true, :durable => false)
-      q.subscribe(:exclusive => false, :manual_ack => false) do |delivery_info, properties, payload|
-        delivered_keys << delivery_info.routing_key
-        delivered_data << payload
+
+      q  = ch.queue("", :exclusive => true)
+      x  = ch.fanout("amq.fanout")
+      q.bind(x)
+
+      rk = "a" * 254
+      x.publish("xyzzy", :routing_key => rk, :persistent => true)
+
+      sleep(1)
+      message_count = q.message_count
+
+      _, _, payload = q.pop
+
+      ch.close
+
+      return message_count, payload
+    end
+  end
+
+  class RabbitMQSampleConsumer < RabbitMQActor
+    def consume_basic(queue_name)
+      delivered_keys = []
+      delivered_data = []
+
+      t = Thread.new do
+        ch = @c.create_channel
+        q = ch.queue(queue_name, :auto_delete => true, :durable => false)
+        q.subscribe(:exclusive => false, :manual_ack => false) do |delivery_info, properties, payload|
+          delivered_keys << delivery_info.routing_key
+          delivered_data << payload
+        end
+      end
+      t.abort_on_exception = true
+      sleep 0.5
+
+      ch = @c.create_channel
+      x  = ch.default_exchange
+      x.publish("hello", :routing_key => queue_name)
+
+      sleep 0.7
+
+      message_count = ch.queue(queue_name, :auto_delete => true, :durable => false).message_count
+
+      ch.close
+
+      return delivered_keys, delivered_data, message_count
+    end
+  end
+
+  describe 'Celluloid::IO integration' do
+    before do
+      Celluloid.boot
+    end
+
+    after do
+      Celluloid.shutdown
+    end
+
+    context 'when intializing a new RabbitMQActor' do
+      it 'connects successfully' do
+        actor = RabbitMQActor.new
+
+        actor.terminate
+      end
+
+      it 'converts the socket to a Celluloid::IO socket' do
+        actor = RabbitMQActor.new
+        expect(actor.c.transport.socket).to be_instance_of(Celluloid::IO::TCPSocket)
+        actor.terminate
       end
     end
-    t.abort_on_exception = true
-    sleep 0.5
 
-    ch = @c.create_channel
-    x  = ch.default_exchange
-    x.publish("hello", :routing_key => queue_name)
+    context 'when producing a message' do
+      it 'is available in RabbitMQ' do
+        actor = RabbitMQSampleProducer.new
+        message_count, payload = actor.publish_basic
 
-    sleep 0.7
-
-    message_count = ch.queue(queue_name, :auto_delete => true, :durable => false).message_count
-
-    ch.close
-
-    return delivered_keys, delivered_data, message_count
-  end
-end
-
-describe 'Celluloid::IO integration' do
-  before do
-    Celluloid.boot
-  end
-
-  after do
-    Celluloid.shutdown
-  end
-
-  context 'when intializing a new RabbitMQActor' do
-    it 'connects successfully' do
-      actor = RabbitMQActor.new
-
-      actor.terminate
+        expect(message_count).to eq 1
+        expect(payload).to eq "xyzzy"
+      end
     end
 
-    it 'converts the socket to a Celluloid::IO socket' do
-      actor = RabbitMQActor.new
-      expect(actor.c.transport.socket).to be_instance_of(Celluloid::IO::TCPSocket)
-      actor.terminate
+    context 'when consuming a message' do
+      let(:queue_name) { 'celluloidiotest' }
+
+      it 'registers the consumer' do
+        actor = RabbitMQSampleConsumer.new
+        delivered_keys, delivered_data, message_count = actor.consume_basic(queue_name)
+
+        expect(delivered_keys).to include(queue_name)
+        expect(delivered_data).to include("hello")
+        expect(message_count).to eq(0)
+
+      end
     end
   end
-
-  context 'when producing a message' do
-    it 'is available in RabbitMQ' do
-      actor = RabbitMQSampleProducer.new
-      message_count, payload = actor.publish_basic
-
-      expect(message_count).to eq 1
-      expect(payload).to eq "xyzzy"
-    end
-  end
-
-  context 'when consuming a message' do
-    let(:queue_name) { 'celluloidiotest' }
-
-    it 'registers the consumer' do
-      actor = RabbitMQSampleConsumer.new
-      delivered_keys, delivered_data, message_count = actor.consume_basic(queue_name)
-
-      expect(delivered_keys).to include(queue_name)
-      expect(delivered_data).to include("hello")
-      expect(message_count).to eq(0)
-
-    end
-  end
+rescue LoadError => e
+  puts "Skipping Celluloid::IO integration specs.\nReason: #{e.inspect}"
 end

--- a/spec/higher_level_api/integration/celluloid_io_integration_spec.rb
+++ b/spec/higher_level_api/integration/celluloid_io_integration_spec.rb
@@ -1,0 +1,119 @@
+require 'celluloid/current'
+require 'celluloid/io'
+require "spec_helper"
+
+class RabbitMQActor
+  include Celluloid::IO
+
+  attr_reader :c
+
+  def initialize
+    @c = Bunny.new(:user => "bunny_gem", :password => "bunny_password", :vhost => "bunny_testbed")
+    @c.start
+  end
+
+  def terminate
+    @c.stop
+    super
+  end
+end
+
+class RabbitMQSampleProducer < RabbitMQActor
+  def publish_basic
+    ch = @c.create_channel
+
+    q  = ch.queue("", :exclusive => true)
+    x  = ch.fanout("amq.fanout")
+    q.bind(x)
+
+    rk = "a" * 254
+    x.publish("xyzzy", :routing_key => rk, :persistent => true)
+
+    sleep(1)
+    message_count = q.message_count
+
+    _, _, payload = q.pop
+
+    ch.close
+
+    return message_count, payload
+  end
+end
+
+class RabbitMQSampleConsumer < RabbitMQActor
+  def consume_basic(queue_name)
+    delivered_keys = []
+    delivered_data = []
+
+    t = Thread.new do
+      ch = @c.create_channel
+      q = ch.queue(queue_name, :auto_delete => true, :durable => false)
+      q.subscribe(:exclusive => false, :manual_ack => false) do |delivery_info, properties, payload|
+        delivered_keys << delivery_info.routing_key
+        delivered_data << payload
+      end
+    end
+    t.abort_on_exception = true
+    sleep 0.5
+
+    ch = @c.create_channel
+    x  = ch.default_exchange
+    x.publish("hello", :routing_key => queue_name)
+
+    sleep 0.7
+
+    message_count = ch.queue(queue_name, :auto_delete => true, :durable => false).message_count
+
+    ch.close
+
+    return delivered_keys, delivered_data, message_count
+  end
+end
+
+describe 'Celluloid::IO integration' do
+  before do
+    Celluloid.boot
+  end
+
+  after do
+    Celluloid.shutdown
+  end
+
+  context 'when intializing a new RabbitMQActor' do
+    it 'connects successfully' do
+      actor = RabbitMQActor.new
+
+      actor.terminate
+    end
+
+    it 'converts the socket to a Celluloid::IO socket' do
+      actor = RabbitMQActor.new
+      expect(actor.c.transport.socket).to be_instance_of(Celluloid::IO::TCPSocket)
+      actor.terminate
+    end
+  end
+
+  context 'when producing a message' do
+    it 'is available in RabbitMQ' do
+      actor = RabbitMQSampleProducer.new
+      message_count, payload = actor.publish_basic
+
+      expect(message_count).to eq 1
+      expect(payload).to eq "xyzzy"
+    end
+  end
+
+  context 'when consuming a message' do
+    let(:queue_name) { 'celluloidiotest' }
+
+    it 'registers the consumer' do
+      actor = RabbitMQSampleConsumer.new
+      delivered_keys, delivered_data, message_count = actor.consume_basic(queue_name)
+
+      expect(delivered_keys).to include(queue_name)
+      expect(delivered_data).to include("hello")
+      expect(message_count).to eq(0)
+
+    end
+  end
+end

--- a/spec/higher_level_api/integration/celluloid_io_integration_spec.rb
+++ b/spec/higher_level_api/integration/celluloid_io_integration_spec.rb
@@ -1,6 +1,7 @@
 require 'celluloid/current'
+require 'celluloid/test'
 require 'celluloid/io'
-require "spec_helper"
+require 'spec_helper'
 
 class RabbitMQActor
   include Celluloid::IO

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,6 @@ $LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
 require 'bundler'
 Bundler.setup(:default, :test)
 
-
 require "effin_utf8"
 require "bunny"
 require "rabbitmq/http/client"


### PR DESCRIPTION
This PR aims to provide support for cooperation with Celluloid::IO's reactor when it is in use.
Fixes #413 