### PR TITLE
Allow switching the socket class

### DIFF
--- a/lib/bunny/cruby/socket.rb
+++ b/lib/bunny/cruby/socket.rb
@@ -13,12 +13,13 @@ module Bunny
     WRITE_RETRY_EXCEPTION_CLASSES = [Errno::EAGAIN, Errno::EWOULDBLOCK, IO::WaitWritable]
 
     def self.open(host, port, options = {})
-      socket = ::Socket.tcp(host, port, nil, nil,
+      @socket_impl = options.fetch(:socket_impl, ::Socket)
+      socket = @socket_impl.tcp(host, port, nil, nil,
                             connect_timeout: options[:connect_timeout])
-      if ::Socket.constants.include?('TCP_NODELAY') || ::Socket.constants.include?(:TCP_NODELAY)
-        socket.setsockopt(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, true)
+      if @socket_impl.constants.include?('TCP_NODELAY') || @socket_impl.constants.include?(:TCP_NODELAY)
+        socket.setsockopt(@socket_impl::IPPROTO_TCP, @socket_impl::TCP_NODELAY, true)
       end
-      socket.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_KEEPALIVE, true) if options.fetch(:keepalive, true)
+      socket.setsockopt(@socket_impl::SOL_SOCKET, @socket_impl::SO_KEEPALIVE, true) if options.fetch(:keepalive, true)
       socket.extend self
       socket.options = { :host => host, :port => port }.merge(options)
       socket

--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -118,6 +118,7 @@ module Bunny
     # @option connection_string_or_opts [Boolean] :automatically_recover (true) Should automatically recover from network failures?
     # @option connection_string_or_opts [Integer] :recovery_attempts (nil) Max number of recovery attempts, nil means forever, 0 means never
     # @option connection_string_or_opts [Boolean] :recover_from_connection_close (true) Recover from server-sent connection.close
+    # @option connection_string_or_opts [Socket] :socket_impl (::Socket) The socket class the transport will use to communicate with RabbitMQ
     #
     # @option optz [String] :auth_mechanism ("PLAIN") Authentication mechanism, PLAIN or EXTERNAL
     # @option optz [String] :locale ("PLAIN") Locale RabbitMQ should use

--- a/lib/bunny/transport.rb
+++ b/lib/bunny/transport.rb
@@ -54,6 +54,8 @@ module Bunny
 
       @writes_mutex       = @session.mutex_impl.new
 
+      @socket_impl = @opts.fetch(:socket_impl, ::Socket)
+
       prepare_tls_context(opts) if @tls_enabled
     end
 
@@ -277,8 +279,9 @@ module Bunny
     def initialize_socket
       begin
         @socket = Bunny::SocketImpl.open(@host, @port,
-          :keepalive      => @opts[:keepalive],
-          :connect_timeout => @connect_timeout)
+          :keepalive       => @opts[:keepalive],
+          :connect_timeout => @connect_timeout,
+          :socket_impl     => @socket_impl)
       rescue StandardError, ClientTimeout => e
         @status = :not_connected
         raise Bunny::TCPConnectionFailed.new(e, self.hostname, self.port)


### PR DESCRIPTION
This is another attempt to fix #413.
It's not clear what we should do about SSLSocket though since Celluloid provides an implementation for it as well. Any ideas?

Also this doesn't have a test just yet but it will.