### PR TITLE
Fix a syntax error in the exchange recovery spec

### DIFF
--- a/spec/unit/exchange_recovery_spec.rb
+++ b/spec/unit/exchange_recovery_spec.rb
@@ -22,11 +22,11 @@ module Bunny
         dst.bind(src2, routing_key: "def")
         dst.bind(src2, routing_key: "ghi")
         dst.bind(src3, routing_key: "jkl")
-        dst.bind(src3, routing_key: "jkl", arguments: {"key": "value"})
+        dst.bind(src3, routing_key: "jkl", arguments: {"key" => "value"})
 
         allow(ch).to receive(:exchange_unbind).twice
         dst.unbind(src2, routing_key: "def")
-        dst.unbind(src3, routing_key: "jkl", arguments: {"key": "value"})
+        dst.unbind(src3, routing_key: "jkl", arguments: {"key" => "value"})
 
         expect(ch).to receive(:exchange_bind).with(src1, dst, routing_key: "abc")
         expect(ch).to receive(:exchange_bind).with(src2, dst, routing_key: "ghi")


### PR DESCRIPTION
While following the contributing guidelines I encountered a syntax error when I ran the specs with `CI=true rspec`.

The hash syntax had an invalid JSON-like syntax, probably mistyped.