### PR TITLE
Raise when calling wait_for_confirms on a closed channel

### DIFF
--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -1783,6 +1783,8 @@ module Bunny
 
     # @private
     def wait_on_confirms_continuations
+      raise_if_no_longer_open!
+
       if @connection.threaded
         t = Thread.current
         @threads_waiting_on_confirms_continuations << t

--- a/spec/higher_level_api/integration/publisher_confirms_spec.rb
+++ b/spec/higher_level_api/integration/publisher_confirms_spec.rb
@@ -60,6 +60,18 @@ describe Bunny::Channel do
           }.not_to raise_error
 
         end
+
+        it "raises an error when called on a closed channel" do
+          ch = connection.create_channel
+
+          ch.confirm_select
+
+          ch.close
+
+          expect {
+            ch.wait_for_confirms
+          }.to raise_error(Bunny::ChannelAlreadyClosed)
+        end
       end
 
       context "when some of the messages get nacked" do


### PR DESCRIPTION
I'm proposing this change based on the discussion and feedback I got in #425.

If a channel is already closed it will receive no new frames and waiting
for confirmations will most likely hang and timeout unless the frames
were somehow already received.

If one wishes to wait for confirmations it’s probably the case that the
user doesn’t expect the channel to be closed and we should notify them
about it by failing early. A channel might be closed by RabbitMQ in case
of a channel-level error for example due to a publishing error.