### PR TITLE
Make wait_for_confirms poll while there're unconfirmed msgs

### DIFF
--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -1790,11 +1790,9 @@ module Bunny
         @threads_waiting_on_confirms_continuations << t
 
         begin
-          outstanding_confirms = false
-          @unconfirmed_set_mutex.synchronize do
-            outstanding_confirms = !@unconfirmed_set.empty?
+          while @unconfirmed_set_mutex.synchronize { !@unconfirmed_set.empty? }
+            @confirms_continuations.poll(@connection.continuation_timeout)
           end
-          @confirms_continuations.poll(@connection.continuation_timeout) if outstanding_confirms
         ensure
           @threads_waiting_on_confirms_continuations.delete(t)
         end


### PR DESCRIPTION
This is an attempt to fix #424.

This should fix a race condition in which Channel#wait_for_confirms may
return before all confirmations are received when using a threaded
connection.

Suppose the following happens:

1. We have a channel in "confirm select" mode.
2. We do a basic_publish to that channel. Some time passes, say a few
   seconds.
3. During that time, an ack is received by Bunny and handled in
   handle_ack_or_nack. @unconfirmed_set is emptied, true is pushed to
   @confirms_continuations.
4. We do a second baslic_publish to that same channel.
5. Immediately afterwards we issue wait_for_confirms to wait for all
   confirmations. It sees that @unconfirmed_set has something in it and
   issues @confirms_continuations.poll but that returns immediately and
   unexpectedly because of the true value pushed to it at step 3. We
   haven't received an ack or nack for the second publish yet.

Doing a bunch of publishes and then calling `wait_for_confirms` is a
completely valid use case and it should block and wait until all acks or
nacks are received. Even if one does a publish and immediately follows
it with `wait_for_confirms`, a race condition exists and may result in
`wait_for_confirms` returning before ack/nack is received.

This is not an issue for non-threaded connections. That is why the spec
includes a test only for threaded connections.