### PR TITLE
Handle graceful shutdown of ConsumerWorkPool when canceling a consumer

### DIFF
--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -952,7 +952,7 @@ module Bunny
         @last_basic_cancel_ok = wait_on_continuations
       end
 
-      maybe_kill_consumer_work_pool! unless any_consumers?
+      @work_pool.shutdown(true) unless any_consumers?
 
       @last_basic_cancel_ok
     end

--- a/lib/bunny/consumer_work_pool.rb
+++ b/lib/bunny/consumer_work_pool.rb
@@ -65,7 +65,7 @@ module Bunny
         end
       end
 
-      return unless wait_for_workers
+      return unless wait_for_workers && @shutdown_timeout
 
       @shutdown_mutex.synchronize do
         @shutdown_conditional.wait(@shutdown_mutex, @shutdown_timeout)

--- a/lib/bunny/consumer_work_pool.rb
+++ b/lib/bunny/consumer_work_pool.rb
@@ -17,9 +17,12 @@ module Bunny
     attr_reader :size
     attr_reader :abort_on_exception
 
-    def initialize(size = 1, abort_on_exception = false)
+    def initialize(size = 1, abort_on_exception = false, shutdown_timeout = nil)
       @size  = size
       @abort_on_exception = abort_on_exception
+      @shutdown_timeout = shutdown_timeout
+      @shutdown_mutex = ::Mutex.new
+      @shutdown_conditional = ::ConditionVariable.new
       @queue = ::Queue.new
       @paused = false
     end
@@ -53,13 +56,19 @@ module Bunny
       !@queue.empty?
     end
 
-    def shutdown
+    def shutdown(wait_for_workers = false)
       @running = false
 
       @size.times do
         submit do |*args|
           throw :terminate
         end
+      end
+
+      return unless wait_for_workers
+
+      @shutdown_mutex.synchronize do
+        @shutdown_conditional.wait(@shutdown_mutex, @shutdown_timeout)
       end
     end
 
@@ -101,6 +110,10 @@ module Bunny
             $stderr.puts e.message
           end
         end
+      end
+
+      @shutdown_mutex.synchronize do
+        @shutdown_conditional.signal unless busy?
       end
     end
   end

--- a/lib/bunny/consumer_work_pool.rb
+++ b/lib/bunny/consumer_work_pool.rb
@@ -17,7 +17,7 @@ module Bunny
     attr_reader :size
     attr_reader :abort_on_exception
 
-    def initialize(size = 1, abort_on_exception = false, shutdown_timeout = nil)
+    def initialize(size = 1, abort_on_exception = false, shutdown_timeout = 60)
       @size  = size
       @abort_on_exception = abort_on_exception
       @shutdown_timeout = shutdown_timeout

--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -337,14 +337,14 @@ module Bunny
     # opened (this operation is very fast and inexpensive).
     #
     # @return [Bunny::Channel] Newly opened channel
-    def create_channel(n = nil, consumer_pool_size = 1, consumer_pool_abort_on_exception = false)
+    def create_channel(n = nil, consumer_pool_size = 1, consumer_pool_abort_on_exception = false, consumer_pool_shutdown_timeout = nil)
       raise ArgumentError, "channel number 0 is reserved in the protocol and cannot be used" if 0 == n
 
       @channel_mutex.synchronize do
         if n && (ch = @channels[n])
           ch
         else
-          ch = Bunny::Channel.new(self, n, ConsumerWorkPool.new(consumer_pool_size || 1, consumer_pool_abort_on_exception))
+          ch = Bunny::Channel.new(self, n, ConsumerWorkPool.new(consumer_pool_size || 1, consumer_pool_abort_on_exception, consumer_pool_shutdown_timeout))
           ch.open
           ch
         end

--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -337,7 +337,7 @@ module Bunny
     # opened (this operation is very fast and inexpensive).
     #
     # @return [Bunny::Channel] Newly opened channel
-    def create_channel(n = nil, consumer_pool_size = 1, consumer_pool_abort_on_exception = false, consumer_pool_shutdown_timeout = nil)
+    def create_channel(n = nil, consumer_pool_size = 1, consumer_pool_abort_on_exception = false, consumer_pool_shutdown_timeout = 60)
       raise ArgumentError, "channel number 0 is reserved in the protocol and cannot be used" if 0 == n
 
       @channel_mutex.synchronize do

--- a/spec/higher_level_api/integration/basic_cancel_spec.rb
+++ b/spec/higher_level_api/integration/basic_cancel_spec.rb
@@ -73,4 +73,37 @@ describe Bunny::Consumer, "#cancel" do
       expect(delivered_data).to be_empty
     end
   end
+
+  context "with a worker pool shutdown timeout configured" do
+    let(:queue_name) { "bunny.queues.#{rand}" }
+
+    it "allows the existing message to be complate processing" do
+      delivered_data = []
+      consumer       = nil
+
+      t = Thread.new do
+        ch         = connection.create_channel(nil, 1, false, 5)
+        q          = ch.queue(queue_name, :auto_delete => true, :durable => false)
+
+        consumer   = Bunny::Consumer.new(ch, q)
+        consumer.on_delivery do |_, _, payload|
+          sleep 2
+          delivered_data << payload
+        end
+
+        q.subscribe_with(consumer, :block => false)
+      end
+      t.abort_on_exception = true
+      sleep 1.0
+
+      ch = connection.create_channel
+      ch.default_exchange.publish("", :routing_key => queue_name)
+      sleep 0.7
+
+      consumer.cancel
+      sleep 1.0
+
+      expect(delivered_data).to_not be_empty
+    end
+  end
 end


### PR DESCRIPTION
This carries on the work of #341 to implement this feature fully. You can now configure a worker pool shutdown timeout when creating the channel (off by default).

Then upon processing of the basic_cancel instead of killing the worker pool as previously done, the worker pool will be shut down and instructed to wait for any workers to complete (within the timeout period).

This allows for a consumer to stop receiving new messages but still be able to complete any existing work before the worker pool is shut down.

All existing behavior remains in the case of closing a connection, we will not wait for workers as the worker might need to ack the message and in this scenario the connection has been closed and this would not be possible.

I will update the documentation as a seperate PR.