### PR TITLE
Fix typo in Bunny::Transport#connected?

### DIFF
--- a/lib/bunny/transport.rb
+++ b/lib/bunny/transport.rb
@@ -92,7 +92,7 @@ module Bunny
     end
 
     def connected?
-      :not_connected == @status && open?
+      :connected == @status && open?
     end
 
     def configure_socket(&block)


### PR DESCRIPTION
There is a typo in `#connected?` method of Bunny::Transport.
