### PR TITLE
Avoid warnings about unused variables

### DIFF
--- a/lib/bunny/reader_loop.rb
+++ b/lib/bunny/reader_loop.rb
@@ -54,7 +54,7 @@ module Bunny
             @network_is_down = true
             @session_thread.raise(Bunny::NetworkFailure.new("caught an unexpected exception in the network loop: #{e.message}", e))
           end
-        rescue Errno::EBADF => ebadf
+        rescue Errno::EBADF => _ebadf
           break if terminate?
           # ignored, happens when we loop after the transport has already been closed
           @mutex.synchronize { @stopping = true }

--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -759,7 +759,7 @@ module Bunny
         shut_down_all_consumer_work_pools!
         maybe_shutdown_reader_loop
         maybe_shutdown_heartbeat_sender
-      rescue ShutdownSignal => sse
+      rescue ShutdownSignal => _sse
         # no-op
       rescue Exception => e
         @logger.warn "Caught an exception when cleaning up after receiving connection.close: #{e.message}"
@@ -1150,7 +1150,7 @@ module Bunny
           begin
             shut_down_all_consumer_work_pools!
             maybe_shutdown_reader_loop
-          rescue ShutdownSignal => sse
+          rescue ShutdownSignal => _sse
             # no-op
           rescue Exception => e
             @logger.warn "Caught an exception when cleaning up after receiving connection.close: #{e.message}"

--- a/lib/bunny/transport.rb
+++ b/lib/bunny/transport.rb
@@ -4,7 +4,7 @@ require "monitor"
 
 begin
   require "openssl"
-rescue LoadError => le
+rescue LoadError => _le
   $stderr.puts "Could not load OpenSSL"
 end
 
@@ -263,7 +263,7 @@ module Bunny
           :connect_timeout => timeout)
 
         true
-      rescue SocketError, Timeout::Error => e
+      rescue SocketError, Timeout::Error => _e
         false
       ensure
         s.close if s
@@ -318,7 +318,7 @@ module Bunny
     def tls_certificate_from(opts)
       begin
         read_client_certificate!
-      rescue MissingTLSCertificateFile => e
+      rescue MissingTLSCertificateFile => _e
         inline_client_certificate_from(opts)
       end
     end
@@ -326,7 +326,7 @@ module Bunny
     def tls_key_from(opts)
       begin
         read_client_key!
-      rescue MissingTLSKeyFile => e
+      rescue MissingTLSKeyFile => _e
         inline_client_key_from(opts)
       end
     end


### PR DESCRIPTION
This PR prepends underscore to variables that are unused (exception variables), so that ruby -w will not output warnings about them.