### PR TITLE
Look up exchange by name in cache to match behavior described in method comment

### DIFF
--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -308,7 +308,7 @@ module Bunny
     # @see http://rubybunny.info/articles/extensions.html RabbitMQ Extensions to AMQP 0.9.1 guide
     # @api public
     def fanout(name, opts = {})
-      Exchange.new(self, :fanout, name, opts)
+      find_exchange(name) || Exchange.new(self, :fanout, name, opts)
     end
 
     # Declares a direct exchange or looks it up in the cache of previously
@@ -326,7 +326,7 @@ module Bunny
     # @see http://rubybunny.info/articles/extensions.html RabbitMQ Extensions to AMQP 0.9.1 guide
     # @api public
     def direct(name, opts = {})
-      Exchange.new(self, :direct, name, opts)
+      find_exchange(name) || Exchange.new(self, :direct, name, opts)
     end
 
     # Declares a topic exchange or looks it up in the cache of previously
@@ -344,7 +344,7 @@ module Bunny
     # @see http://rubybunny.info/articles/extensions.html RabbitMQ Extensions to AMQP 0.9.1 guide
     # @api public
     def topic(name, opts = {})
-      Exchange.new(self, :topic, name, opts)
+      find_exchange(name) || Exchange.new(self, :topic, name, opts)
     end
 
     # Declares a headers exchange or looks it up in the cache of previously
@@ -362,7 +362,7 @@ module Bunny
     # @see http://rubybunny.info/articles/extensions.html RabbitMQ Extensions to AMQP 0.9.1 guide
     # @api public
     def headers(name, opts = {})
-      Exchange.new(self, :headers, name, opts)
+      find_exchange(name) || Exchange.new(self, :headers, name, opts)
     end
 
     # Provides access to the default exchange


### PR DESCRIPTION
The comments above the channel exchange declarations states:
```
Declares a fanout exchange or looks it up in the cache of previously declared exchanges.
```
However, the current code simply creates a new exchange every time, overwriting the value in the cache.

This pull request simply tries to look up the exchange by name in the cache and return it if found, and creates a new one otherwise, similarly to what is done in the `queue` method.