### PR TITLE
Fix #492

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -51,6 +51,13 @@ Bunny now can work with frozen host arrays.
 GitHub issue: [#446](https://github.com/ruby-amqp/bunny/issues/446)
 
 
+### Support Windows SSL CA Cert File Paths
+
+Bunny now treats the default CA cert file paths as paths instead of inline certs.
+
+GitHub issue: [#492](https://github.com/ruby-amqp/bunny/issues/492)
+
+
 
 ## Changes between Bunny 2.5.0 and 2.6.0 (October 15th, 2016)
 

--- a/lib/bunny/transport.rb
+++ b/lib/bunny/transport.rb
@@ -455,9 +455,9 @@ but prone to man-in-the-middle attacks. Please set verify_peer: true in producti
       cert_files = []
       cert_inlines = []
       certs.each do |cert|
-        # if it starts with / then it's a file path that may or may not
-        # exists (e.g. a default OpenSSL path). MK.
-        if File.readable?(cert) || cert =~ /^\//
+        # if it starts with / or C:/ then it's a file path that may or may not
+        # exist (e.g. a default OpenSSL path). MK.
+        if File.readable?(cert) || cert =~ /^([a-z]:?)?\//i
           cert_files.push(cert)
         else
           cert_inlines.push(cert)


### PR DESCRIPTION
Prevents Windows file paths from being treated as inline certs