### PR TITLE
Remove block parameter from new and make run parameter options consistent with new.

### DIFF
--- a/lib/bunny.rb
+++ b/lib/bunny.rb
@@ -58,7 +58,7 @@ module Bunny
   # @see http://rubybunny.info/articles/getting_started.html
   # @see http://rubybunny.info/articles/connecting.html
   # @api public
-  def self.new(connection_string_or_opts = ENV['RABBITMQ_URL'], opts = {}, &block)
+  def self.new(connection_string_or_opts = ENV['RABBITMQ_URL'], opts = {})
     if connection_string_or_opts.respond_to?(:keys) && opts.empty?
       opts = connection_string_or_opts
     end
@@ -72,6 +72,10 @@ module Bunny
 
   def self.run(connection_string_or_opts = ENV['RABBITMQ_URL'], opts = {}, &block)
     raise ArgumentError, 'Bunny#run requires a block' unless block
+
+    if connection_string_or_opts.respond_to?(:keys) && opts.empty?
+      opts = connection_string_or_opts
+    end
 
     client = Session.new(connection_string_or_opts, opts)
 


### PR DESCRIPTION
- Removed unused block parameter 
    If I'm correct. I don't the see the `&block` parameter used. 

- Make `run` parameter options to be consistent with `new`
  
