### PR TITLE
0.7.x: support boolean headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,20 @@
-# https://github.com/travis-ci/travis-ci/wiki/.travis.yml-options
+language: ruby
 bundler_args: --without development
+cache: bundler
+before_script: "./bin/ci/before_build"
 script: "bundle exec rspec spec"
+dist: trusty
 rvm:
-  - 1.8.7
-  - ree
-  - 1.9.2
-  - 1.9.3
-  - rbx-2.0
+  - "2.4.1"
+  - "2.3.4"
+  - "2.2.7"
 notifications:
-  recipients:
-    - celldee@gmail.com
-    - jakub@rabbitmq.com
+  email:
     - skaes@railsexpress.de
-    - eric@5stops.com
+services:
+  - rabbitmq
+branches:
+  only:
+    - 0.7.x-stable
+env:
+  - CI=true

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ group :development do
 end
 
 group :test do
-  gem "rspec", "~> 2.6.0"
+  gem "rspec", "~> 3.6.0"
 end
 
 gemspec

--- a/bin/ci/before_build
+++ b/bin/ci/before_build
@@ -1,0 +1,46 @@
+#!/usr/bin/env ruby
+
+$ctl      = ENV["BUNNY_RABBITMQCTL"]      || ENV["RABBITMQCTL"]      || "sudo rabbitmqctl"
+$plugins  = ENV["BUNNY_RABBITMQ_PLUGINS"] || ENV["RABBITMQ_PLUGINS"] || "sudo rabbitmq-plugins"
+
+def rabbit_control(args)
+  command = "#{$ctl} #{args}"
+  system command
+end
+
+def rabbit_plugins(args)
+  command = "#{$plugins} #{args}"
+  system command
+end
+
+
+# guest:guest has full access to /
+
+rabbit_control 'add_vhost /'
+rabbit_control 'add_user guest guest'
+rabbit_control 'set_permissions -p / guest ".*" ".*" ".*"'
+
+
+# bunny_gem:bunny_password has full access to bunny_testbed
+
+rabbit_control 'add_vhost bunny_testbed'
+rabbit_control 'add_user bunny_gem bunny_password'
+rabbit_control 'set_permissions -p bunny_testbed bunny_gem ".*" ".*" ".*"'
+
+
+# guest:guest has full access to bunny_testbed
+
+rabbit_control 'set_permissions -p bunny_testbed guest ".*" ".*" ".*"'
+
+
+# bunny_reader:reader_password has read access to bunny_testbed
+
+rabbit_control 'add_user bunny_reader reader_password'
+rabbit_control 'set_permissions -p bunny_testbed bunny_reader "^---$" "^---$" ".*"'
+
+# requires RabbitMQ 3.0+
+# rabbit_plugins 'enable rabbitmq_management'
+
+# Reduce retention policy for faster publishing of stats
+rabbit_control "eval 'supervisor2:terminate_child(rabbit_mgmt_sup_sup, rabbit_mgmt_sup), application:set_env(rabbitmq_management,       sample_retention_policies, [{global, [{605, 1}]}, {basic, [{605, 1}]}, {detailed, [{10, 1}]}]), rabbit_mgmt_sup_sup:start_child().'"
+rabbit_control "eval 'supervisor2:terminate_child(rabbit_mgmt_agent_sup_sup, rabbit_mgmt_agent_sup), application:set_env(rabbitmq_management_agent, sample_retention_policies, [{global, [{605, 1}]}, {basic, [{605, 1}]}, {detailed, [{10, 1}]}]), rabbit_mgmt_agent_sup_sup:start_child().'"

--- a/lib/qrack/transport/buffer09.rb
+++ b/lib/qrack/transport/buffer09.rb
@@ -128,7 +128,7 @@ module Qrack
                          when 108 # 'l'
                            table.read(:longlong)
                          when 116 # 't'
-                           table.read(:octet)
+                           table.read(:octet) == 1
                          end
             end
 
@@ -210,6 +210,12 @@ module Qrack
                              when Hash
                                table.write(:octet, 70) # 'F'
                                table.write(:table, value)
+                             when TrueClass
+                               table.write(:octet, 116) # 't'
+                               table.write(:octet, 1)
+                             when FalseClass
+                               table.write(:octet, 116) # 't'
+                               table.write(:octet, 0)
                              end
 
                              table

--- a/spec/spec_08/connection_spec.rb
+++ b/spec/spec_08/connection_spec.rb
@@ -7,7 +7,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), %w[.. .. lib bunny]))
 describe Bunny do
 
   it "should raise an error if the wrong user name or password is used" do
-    b = Bunny.new(:user => 'wrong')
+    b = Bunny.new(:spec => "0.8", :user => 'wrong')
     lambda { b.start}.should raise_error(Bunny::ProtocolError)
   end
 
@@ -22,4 +22,3 @@ describe Bunny do
   end
 
 end
-


### PR DESCRIPTION
According to the specifications, it should be possible to provide boolean values for a header.
Currently the `Buffer.write` method does not support this types and lead to invalid packets.

This PR adds support for writing boolean header, and fixes the reading to return a boolean value.