### PR TITLE
Throw an error for unsupported types

### DIFF
--- a/lib/qrack/transport/buffer09.rb
+++ b/lib/qrack/transport/buffer09.rb
@@ -216,6 +216,8 @@ module Qrack
                              when FalseClass
                                table.write(:octet, 116) # 't'
                                table.write(:octet, 0)
+                             else
+                               raise Qrack::InvalidTypeError, "Cannot write table field for the type of #{value}"
                              end
 
                              table


### PR DESCRIPTION
Here is another PR to close the topic around unsupported types.
This will generate an error on the client side when a header type would have lead to a silently dropped invalid packet. It gives developers a chance to have a direct feedback on such errors.