### PR TITLE
ChangeLog Markdown format repair [ci skip]

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,7 +7,7 @@ No changes yet.
 
 ### amq-protocol Update
 
-Minimum `amq-protocol` version is now [`2.2.0`]](https://github.com/ruby-amqp/amq-protocol/blob/master/ChangeLog.md#changes-between-210-and-220-may-11th-2017) which includes
+Minimum `amq-protocol` version is now [`2.2.0`](https://github.com/ruby-amqp/amq-protocol/blob/master/ChangeLog.md#changes-between-210-and-220-may-11th-2017) which includes
 a change in [how timestamps are encoded](https://github.com/ruby-amqp/amq-protocol/issues/64).
 
 


### PR DESCRIPTION
This PR repairs an invalidly formatted Markdown link which made the ChangeLog harder to read.