### PR TITLE
Treat string and symbols the same when specifying 'server' or :server…

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,13 +1,6 @@
-## Changes between Bunny 2.7.1 and 2.7.2 (unreleased)
+## Changes between Bunny 2.7.x and 2.8.0 (unreleased)
 
-### Reading a Frame without Payload Could Result in a `Bunny::NoFinalOctetError`
-
-Reading a frame without payload (e.g. a heartbeat frame) could result in a `Bunny::NoFinalOctetError`
-with mostly idle connections.
-
-GitHub issue: https://github.com/ruby-amqp/bunny/issues/521.
-
-Contributed by GPif.
+No changes yet.
 
 
 ## Changes between Bunny 2.7.0 and 2.7.1 (Sep 25th, 2017)

--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -1257,7 +1257,7 @@ module Bunny
 
     # @private
     def negotiate_value(client_value, server_value)
-      return server_value if client_value == :server
+      return server_value if [:server, "server"].include? client_value
 
       if client_value == 0 || server_value == 0
         [client_value, server_value].max


### PR DESCRIPTION
When loading config values from yaml file you can't easily pass in a symbol like :server. So  this PR treats 'server' the same as :server so that string values can be used from .yml files.