### PR TITLE
Treat string and symbols the same when specifying 'server' or :server

### DIFF
--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -1257,7 +1257,7 @@ module Bunny
 
     # @private
     def negotiate_value(client_value, server_value)
-      return server_value if client_value == :server
+      return server_value if [:server, "server"].include?(client_value)
 
       if client_value == 0 || server_value == 0
         [client_value, server_value].max


### PR DESCRIPTION
When loading config values from yaml file you can't easily pass in a symbol like :server. So  this PR treats 'server' the same as :server so that string values can be used from .yml files.