### PR TITLE
Fix incompatibility with JRuby 9K - #356

### DIFF
--- a/lib/bunny/jruby/socket.rb
+++ b/lib/bunny/jruby/socket.rb
@@ -8,6 +8,20 @@ module Bunny
     module Socket
       include Bunny::Socket
 
+      def self.open(host, port, options = {})
+        socket = ::Socket.tcp(host, port, nil, nil,
+                              connect_timeout: options[:connect_timeout])
+        if ::Socket.constants.include?('TCP_NODELAY') || ::Socket.constants.include?(:TCP_NODELAY)
+          socket.setsockopt(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, true)
+        end
+        socket.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_KEEPALIVE, true) if options.fetch(:keepalive, true)
+        socket.extend self
+        socket.options = { :host => host, :port => port }.merge(options)
+        socket
+      rescue Errno::ETIMEDOUT
+        raise ClientTimeout
+      end
+
       # Reads given number of bytes with an optional timeout
       #
       # @param [Integer] count How many bytes to read
@@ -16,17 +30,17 @@ module Bunny
       # @return [String] Data read from the socket
       # @api public
       def read_fully(count, timeout = nil)
-        return nil if @__bunny_socket_eof_flag__
-
         value = ''
+
         begin
           loop do
-            value << readpartial(count - value.bytesize)
+            value << read_nonblock(count - value.bytesize)
             break if value.bytesize >= count
           end
         rescue EOFError
-          # @eof will break Rubinius' TCPSocket implementation. MK.
-          @__bunny_socket_eof_flag__ = true
+          # JRuby specific fix via https://github.com/jruby/jruby/issues/1694#issuecomment-54873532
+          IO.select([self], nil, nil, timeout)
+          retry
         rescue *READ_RETRY_EXCEPTION_CLASSES
           if IO.select([self], nil, nil, timeout)
             retry
@@ -34,8 +48,10 @@ module Bunny
             raise Timeout::Error, "IO timeout when reading #{count} bytes"
           end
         end
+
         value
       end # read_fully
+
     end
   end
 end


### PR DESCRIPTION
Currently bunny doesn't work at all with JRuby 9K - when trying to connect it fails with the behaviour described in #356.

This PR fixes that plus a couple of more issues, the integration specs are fully green but the full specs fail so this should be regarded as WIP + feedback on the changes.

Yes we have a valid option for JRuby (March Hare gem) but it would be nice for Bunny at least to function with JRuby 9K even if that implies a bigger overhead than native Java libs - Im thinking for some smaller apps having the full Bunny gem API might be useful.
