### PR TITLE
Do not log to error when automatically recover

### DIFF
--- a/lib/bunny/reader_loop.rb
+++ b/lib/bunny/reader_loop.rb
@@ -36,11 +36,11 @@ module Bunny
         rescue AMQ::Protocol::EmptyResponseError, IOError, SystemCallError, Timeout::Error => e
           break if terminate? || @session.closing? || @session.closed?
 
-          log_exception(e)
           @network_is_down = true
           if @session.automatically_recover?
             @session.handle_network_failure(e)
           else
+            log_exception(e)
             @session_thread.raise(Bunny::NetworkFailure.new("detected a network failure: #{e.message}", e))
           end
         rescue ShutdownSignal => _


### PR DESCRIPTION
This prevents exceptions to be logged to error when automatically recover is enabled. I don't know if it should log in general in this case, but I think at least not to error.