### PR TITLE
Set default value for opts[:verify_peer] to true only when all of the keys checked are nil.

### DIFF
--- a/lib/bunny/transport.rb
+++ b/lib/bunny/transport.rb
@@ -341,7 +341,7 @@ module Bunny
     end
 
     def prepare_tls_context(opts)
-      if (opts[:verify_ssl] || opts[:verify_peer] || opts[:verify]).nil?
+      if opts.values_at(:verify_ssl, :verify_peer, :verify).all?(&:nil?)
         opts[:verify_peer] = true
       end
 


### PR DESCRIPTION
This is for issue #541 which I filed.

It appears that this bit of code is intended to force peer verification when none of the appropriate options have been provided. 

However, the existing conditional does not do this. For example, if in the options we pass in verify_peer: false and leave the other two blank then we evaluate:

`
(nil || false || nil).nil?
`

which is actually true and winds up setting `opts[:verify_peer] = true`, which is unlikely to be what we wanted when we explicitly passed in a value of false. (In fact here the first two can independently be any combination of nil and false and the third one will determine whether the parenthesized piece is nil or false.)

This modification only sets the default when all three of these keys are actually nil.