### PR TITLE
Issue #549: Move connection to closed state when recovery attempts fail

### DIFF
--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -757,6 +757,7 @@ module Bunny
         end
       else
         @logger.error "Ran out of recovery attempts (limit set to #{@max_recovery_attempts})"
+        self.close
       end
     end
 

--- a/spec/issues/issue549_spec.rb
+++ b/spec/issues/issue549_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe Bunny::Session do
+  context 'when retry attempts have been exhausted' do
+    let(:io) { StringIO.new } # keep test output clear
+
+    def create_session
+      described_class.new(
+        host: 'fake.host',
+        recovery_attempts: 0,
+        connection_timeout: 0,
+        network_recovery_interval: 0,
+        logfile: io,
+      )
+    end
+
+    it 'closes the session' do
+      session = create_session
+      session.handle_network_failure(StandardError.new)
+      expect(session.closed?).to be true
+    end
+
+    it 'stops the reader loop' do
+      session = create_session
+      reader_loop = session.reader_loop
+      session.handle_network_failure(StandardError.new)
+      expect(reader_loop.stopping?).to be true
+    end
+  end
+end


### PR DESCRIPTION
See #549 for a more thorough description of the problem.

A gist:

When the RabbitMQ server goes down, the session attempts to continually
reconnect, only stopping once the recovery_attempts threshold is met (or
forever is this parameter is not provided). In the former case, there
are no exceptions raised to indicate to clients that new messages are
not being processed. This patch provides that by initiating close
from the session, which will close related channels and the reader
loop. Then, an exception will be thrown when subsequent operations are
performed.

Client code will now be able to rescue `Bunny::ConnectionClosedError` to gracefully degrade.