### PR TITLE
Resolve a few warnings about uninitialized variables.

### DIFF
--- a/lib/bunny/consumer_work_pool.rb
+++ b/lib/bunny/consumer_work_pool.rb
@@ -25,6 +25,7 @@ module Bunny
       @shutdown_conditional = ::ConditionVariable.new
       @queue = ::Queue.new
       @paused = false
+      @running = false
     end
 
 

--- a/lib/bunny/cruby/ssl_socket.rb
+++ b/lib/bunny/cruby/ssl_socket.rb
@@ -24,6 +24,11 @@ module Bunny
                                       [Errno::EAGAIN, Errno::EWOULDBLOCK, IO::WaitWritable]
                                     end
 
+      def initialize(*args)
+        super
+        @__bunny_socket_eof_flag__ = false
+      end
+
       # Reads given number of bytes with an optional timeout
       #
       # @param [Integer] count How many bytes to read

--- a/lib/bunny/jruby/ssl_socket.rb
+++ b/lib/bunny/jruby/ssl_socket.rb
@@ -8,6 +8,11 @@ module Bunny
       # methods found in Bunny::Socket.
       class SSLSocket < Bunny::SSLSocket
 
+        def initialize(*args)
+          super
+          @__bunny_socket_eof_flag__ = false
+        end
+
         # Reads given number of bytes with an optional timeout
         #
         # @param [Integer] count How many bytes to read

--- a/lib/bunny/reader_loop.rb
+++ b/lib/bunny/reader_loop.rb
@@ -16,6 +16,10 @@ module Bunny
       @logger         = @session.logger
 
       @mutex          = Mutex.new
+
+      @stopping        = false
+      @stopped         = false
+      @network_is_down = false
     end
 
 

--- a/lib/bunny/transport.rb
+++ b/lib/bunny/transport.rb
@@ -57,6 +57,8 @@ module Bunny
 
       @writes_mutex       = @session.mutex_impl.new
 
+      @socket = nil
+
       prepare_tls_context(opts) if @tls_enabled
     end
 


### PR DESCRIPTION
consumer_work_pool.rb
  * During initialize, work pool is not running; set @running to false.

cruby/ssl_socket.rb, jruby/ssl_socket.rb
  * Add initialize method to init @__bunny_socket_eof_flag__ to false while
    still passing args, if any, to superclass

reader_loop.rb
  * Initialize flags used in the loop to sensible values given that:
      Not stopping or stopped (since we havent started), and don't know if
      network is down, yet.

session.rb
  * Move initialization of variables referenced by to_s before the call to
    init_default_logger, which calls to_s.
  * Initialize @transport, @heartbeat_sender, and @last_connection_error before
    they are referenced.
  * Removed code referencing @socket_configurator.
    The commit that added it: aa2642c8da2a294baa5d96dc4b11f56278283f90
    The commit that removed setting it: 7a1b5578e14acd69463909275b22a1293059a9ff
    The library doesn't sets it anywhere via instance_variable_set but users
    might've set it this way instead of using configure_socket..

transport.rb
  * Initialize @socket before it is referenced.

fixes #563