### PR TITLE
Removing effin dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ extend Module.new {
 }
 
 gem "rake", ">= 12.3.1"
-gem "effin_utf8"
 
 group :development do
   gem "yard"


### PR DESCRIPTION
Not required anymore since ruby 2.x has utf-8 as default encoding