### PR TITLE
exclude bin/ci directory from built .gem file

### DIFF
--- a/bunny.gemspec
+++ b/bunny.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
 
   # Files.
   s.extra_rdoc_files = ["README.md"]
-  s.files         = `git ls-files`.split("\n")
+  s.files         = `git ls-files`.split("\n").reject { |f| f.match(%r{^bin/ci/}) }
   s.test_files    = `git ls-files -- spec/*`.split("\n")
   s.require_paths = ["lib"]
 end


### PR DESCRIPTION
the symlink to `bin/ci/before_build` [was recently added](bin/ci/before_build) for travis ci support, but because it is more a linux/unix convention, it breaks bunny installation on Windows, with the following error messages.
```
Installing bunny 2.14.0
Errno::EACCES: Permission denied @ rb_file_s_symlink - (bin/ci/before_build.sh,
```
Assuming this `bin/ci` directory is unnecessary as part of installable gem file, this PR simply excludes it. 