### PR TITLE
use read/write timeout for channel closing

### DIFF
--- a/lib/qrack/client.rb
+++ b/lib/qrack/client.rb
@@ -79,7 +79,7 @@ module Qrack
 
       # Close all active channels
       channels.each do |c|
-        Bunny::Timer::timeout(@disconnect_timeout) { c.close } if c.open?
+        Bunny::Timer::timeout(@read_write_timeout) { c.close } if c.open?
       end
 
       # Close connection to AMQP server


### PR DESCRIPTION
This applies the normal read/write timeout to closing a channel instead
of the general connect/disconnect timeout.

cc: @skaes @boosty , referring to: https://github.com/xing/beetle/pull/54#discussion_r260740480