### PR TITLE
Pass a block for peer cert / cert chain logging

### DIFF
--- a/lib/bunny/transport.rb
+++ b/lib/bunny/transport.rb
@@ -371,7 +371,7 @@ module Bunny
     end
 
     def log_peer_certificate_info(severity, peer_cert, prefix = "Peer's leaf certificate")
-      @logger.add(severity, peer_certificate_info(peer_cert, prefix))
+      @logger.add(severity) { peer_certificate_info(peer_cert, prefix) }
     end
 
     def log_peer_certificate_chain_info(severity, chain)


### PR DESCRIPTION
There's actually a more interesting error happening here where we have:
1. `tls: true, verify_peer: false`, there's a custom CA cert added, no client cert/key.
2. Rabbitmq has the following options:
```
    {ssl_options, [
                   {cacertfile,"/etc/path/to/ssl/certs/ca.pem"},
                   {certfile,"/etc/path/to/ssl/certs/certfile.pem"},
                   {keyfile,"/etc/rabbitmq/ssl/keyfile.pem"},
                   {verify,verify_none},
                   {fail_if_no_peer_cert,false}
                   ,{versions, ['tlsv1.2']}
                  ]},
```

And then when we go to create a new connection using bunny (> 2.13.0), we call `x.value` in `peer_certificate_info`:
```
peer_cert.extensions.map { |x| x.value }
```
We end up with an `SSL_read: nested asn1 error (OpenSSL::SSL::SSLError)` error:
```
         8: from /home/film42/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bunny-2.14.1/lib/bunny/session.rb:317:in `start'
         7: from /home/film42/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bunny-2.14.1/lib/bunny/session.rb:1164:in `init_connection'
         6: from /home/film42/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bunny-2.14.1/lib/bunny/transport.rb:261:in `read_next_frame'
         5: from /home/film42/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bunny-2.14.1/lib/bunny/transport.rb:239:in `read_fully'
         4: from /home/film42/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bunny-2.14.1/lib/bunny/cruby/ssl_socket.rb:44:in `read_fully'
         3: from /home/film42/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bunny-2.14.1/lib/bunny/cruby/ssl_socket.rb:44:in `loop'
         2: from /home/film42/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bunny-2.14.1/lib/bunny/cruby/ssl_socket.rb:45:in `block in read_fully'
         1: from /home/film42/.rbenv/versions/2.5.1/lib/ruby/2.5.0/openssl/buffering.rb:182:in `read_nonblock'
/home/film42/.rbenv/versions/2.5.1/lib/ruby/2.5.0/openssl/buffering.rb:182:in `sysread_nonblock': SSL_read: nested asn1 error (OpenSSL::SSL::SSLError)
```

Not calling `x.value` on the cert fixes the problem. Understanding why this is failing is a bigger problem, but I haven't discovered this yet. For now, though, this ensures the code is never called unless the log_level is set to `DEBUG`.