### PR TITLE
Do not join @thread if that is the current Thread

### DIFF
--- a/lib/bunny/reader_loop.rb
+++ b/lib/bunny/reader_loop.rb
@@ -116,7 +116,7 @@ module Bunny
     end
 
     def join
-      @thread.join if @thread
+      @thread.join if @thread && @thread != Thread.current
     end
 
     def kill


### PR DESCRIPTION
If you're running multiple Bunny connections in a pooled manner, for example using the gem `connection_pool`, the threading model can be altered by the pooling gem to disable handling of exceptions.

For example, the gem `connection_pool` disables the handling when it creates an instance, and enables the handling when you're using a connection:

```ruby
  def with(options = {})
    Thread.handle_interrupt(Exception => :never) do
      conn = checkout(options)
      begin
        Thread.handle_interrupt(Exception => :immediate) do
          yield conn
        end
      ensure
        checkin
      end
    end
  end
```

When you've setup a connection and released it to the pool, it slumbers in a Thread of which the handling of exceptions is disabled. If you receive a (forced) disconnect or a NetworkError occurs, it triggers the recovery (when enabled) of Bunny. This recovery relies on a ShutdownSignal to be raised on the `reader_loop` thread which needs to be caught by the `clean_up_on_shutdown` in `Session`. Because the exception is not handled anymore, the code in `maybe_shutdown_reader_loop` in `Session` tries to join the `reader_loop` thread to force a re-raise of a thrown unhandled exception. That join is done on the `reader_loop` thread which is the same thread that started the recovery so we'll receive a ThreadError telling us "Target thread must not be current thread (ThreadError)".

To prevent the above from happening we can check if the thread we're trying to join is the same thread that is currently running and not join if it is the same thread.

This PR fixes #589.