### PR TITLE
issue202_spec: don't connect to the internet

### DIFF
--- a/spec/issues/issue202_spec.rb
+++ b/spec/issues/issue202_spec.rb
@@ -4,7 +4,7 @@ describe Bunny::Session do
   context "with unreachable host" do
     it "raises Bunny::TCPConnectionFailed" do
       begin
-        conn = Bunny.new(:hostname => "192.192.192.192")
+        conn = Bunny.new(:hostname => "127.0.0.254", :port => 1433)
         conn.start
 
         fail "expected 192.192.192.192 to be unreachable"


### PR DESCRIPTION
192.192.192.192 is a real server on the internet, and every time someone
runs the bunny test suite it will receive a connection attempt.

127.0.0.254 is a local address, and 1433 is the port for Microsoft SQL
Server. So, unless you are runinng the bunny test suite on a Microsoft
SQL server that happens to listen to all interfaces, the connection
attempt should always fail (and fail faster).