### PR TITLE
exchange_recovery_spec: drop require_relative to lib

### DIFF
--- a/spec/unit/exchange_recovery_spec.rb
+++ b/spec/unit/exchange_recovery_spec.rb
@@ -1,5 +1,5 @@
-require_relative '../../lib/bunny/channel'
-require_relative '../../lib/bunny/exchange'
+require 'bunny/channel'
+require 'bunny/exchange'
 
 module Bunny
   describe Exchange do


### PR DESCRIPTION
rspec already automatically adds lib to the $LOAD_PATH, and this hinders
initiatives such as Debian's practice of running the test suite against
the package installed system-wide (as opposed to against the source tree).