### PR TITLE
Support connection name

### DIFF
--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -201,7 +201,8 @@ module Bunny
 
       client_props         = opts[:properties] || opts[:client_properties] || {}
       @client_properties   = DEFAULT_CLIENT_PROPERTIES.merge(client_props)
-      @connection_name     = @client_properties.fetch(:connection_name, nil)
+                                                      .merge(connection_name: opts[:connection_name])
+      @connection_name     = @client_properties[:connection_name]
       @mechanism           = normalize_auth_mechanism(opts.fetch(:auth_mechanism, "PLAIN"))
       @credentials_encoder = credentials_encoder_for(@mechanism)
       @locale              = @opts.fetch(:locale, DEFAULT_LOCALE)

--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -89,6 +89,7 @@ module Bunny
     # @return [Integer] Timeout for blocking protocol operations (queue.declare, queue.bind, etc), in milliseconds. Default is 15000.
     attr_reader :continuation_timeout
     attr_reader :network_recovery_interval
+    attr_reader :connection_name
     attr_accessor :socket_configurator
 
     # @param [String, Hash] connection_string_or_opts Connection string or a hash of connection options
@@ -128,6 +129,7 @@ module Bunny
     #
     # @option optz [String] :auth_mechanism ("PLAIN") Authentication mechanism, PLAIN or EXTERNAL
     # @option optz [String] :locale ("PLAIN") Locale RabbitMQ should use
+    # @option optz [String] :connection_name (nil) Client-provided connection name, if any. Note that the value returned does not uniquely identify a connection and cannot be used as a connection identifier in HTTP API requests.
     #
     # @see http://rubybunny.info/articles/connecting.html Connecting to RabbitMQ guide
     # @see http://rubybunny.info/articles/tls.html TLS/SSL guide
@@ -199,6 +201,7 @@ module Bunny
 
       client_props         = opts[:properties] || opts[:client_properties] || {}
       @client_properties   = DEFAULT_CLIENT_PROPERTIES.merge(client_props)
+      @connection_name     = @client_properties.fetch(:connection_name, nil)
       @mechanism           = normalize_auth_mechanism(opts.fetch(:auth_mechanism, "PLAIN"))
       @credentials_encoder = credentials_encoder_for(@mechanism)
       @locale              = @opts.fetch(:locale, DEFAULT_LOCALE)

--- a/spec/higher_level_api/integration/connection_spec.rb
+++ b/spec/higher_level_api/integration/connection_spec.rb
@@ -562,8 +562,20 @@ describe Bunny::Session do
   end
 
   context "initialized with a custom connection name" do
-    it "uses provided connection name" do
-      conn = Bunny.new(properties: { connection_name: 'test_name' })
+    it "uses provided connection name with default connection string" do
+      conn = Bunny.new(nil, connection_name: 'test_name')
+
+      expect(conn.connection_name).to eq 'test_name'
+    end
+
+    it "uses provided connection name with custom connection string" do
+      conn = Bunny.new('amqp://guest:guest@rabbitmq:5672', connection_name: 'test_name')
+
+      expect(conn.connection_name).to eq 'test_name'
+    end
+
+    it "uses provided connection name with hash options" do
+      conn = Bunny.new(user: 'user', password: 'p455w0rd', connection_name: 'test_name')
 
       expect(conn.connection_name).to eq 'test_name'
     end

--- a/spec/higher_level_api/integration/connection_spec.rb
+++ b/spec/higher_level_api/integration/connection_spec.rb
@@ -560,4 +560,12 @@ describe Bunny::Session do
       described_class.new(logger: logger)
     end
   end
+
+  context "initialized with a custom connection name" do
+    it "uses provided connection name" do
+      conn = Bunny.new(properties: { connection_name: 'test_name' })
+
+      expect(conn.connection_name).to eq 'test_name'
+    end
+  end
 end

--- a/spec/lower_level_api/integration/basic_consume_spec.rb
+++ b/spec/lower_level_api/integration/basic_consume_spec.rb
@@ -96,10 +96,4 @@ describe Bunny::Channel, "#basic_consume" do
       ch.close
     end
   end
-
-  it "propagates the connection_name to the client_properties" do
-    named_connection = Bunny.new(properties: { connection_name: 'test_name' })
-
-    expect(named_connection.connection_name).to eq 'test_name'
-  end
 end

--- a/spec/lower_level_api/integration/basic_consume_spec.rb
+++ b/spec/lower_level_api/integration/basic_consume_spec.rb
@@ -96,4 +96,10 @@ describe Bunny::Channel, "#basic_consume" do
       ch.close
     end
   end
+
+  it "propagates the connection_name to the client_properties" do
+    named_connection = Bunny.new(properties: { connection_name: 'test_name' })
+
+    expect(named_connection.connection_name).to eq 'test_name'
+  end
 end


### PR DESCRIPTION
related to https://github.com/ruby-amqp/bunny/issues/599.

- adds connection_name as optional client_property
- adds unit test