### PR TITLE
fix automatically_recover config option

### DIFF
--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -172,7 +172,7 @@ module Bunny
       @automatically_recover = if opts[:automatically_recover].nil? && opts[:automatic_recovery].nil?
                                  true
                                else
-                                 opts[:automatically_recover] || opts[:automatic_recovery]
+                                 opts[:automatically_recover] | opts[:automatic_recovery]
                                end
       @recovering_from_network_failure = false
       @max_recovery_attempts = opts[:recovery_attempts]


### PR DESCRIPTION
If option **automatically_recover: false** and **automatic_recovery** not set

`opts[:automatically_recover] || opts[:automatic_recovery] #=> nil
`
Other cases
```
false || nil #=> nil
nil || false #=> false

false | nil #=> false
nil | false #=> false
```
automatically_recover? return nil
https://github.com/ruby-amqp/bunny/blob/master/lib/bunny/session.rb#L456

```
# @return [Boolean] true if this connection has automatic recovery from network failure enabled
def automatically_recover?
  @automatically_recover
end
```