### PR TITLE
Update ChangeLog.md

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1738,7 +1738,7 @@ This is rarely necessary but helps make sure no error goes unnoticed.
 Example:
 
 ``` ruby
-channel.on_error |ch, channel_close|
+channel.on_error do |ch, channel_close|
   puts channel_close.inspect
 end
 ```


### PR DESCRIPTION
Fix invalid syntax.

I just discovered the `on_error` callback through the changelog and I tried to copy-paste the sample code. Others have probably encountered this, and no doubt more people will. So I figured I can contribute a fix.