### PR TITLE
Remove test_files from gemspec

### DIFF
--- a/bunny.gemspec
+++ b/bunny.gemspec
@@ -30,6 +30,5 @@ Gem::Specification.new do |s|
   # Files.
   s.extra_rdoc_files = ["README.md"]
   s.files         = `git ls-files -- lib/*`.split("\n").reject { |f| f.match(%r{^bin/ci/}) }
-  s.test_files    = `git ls-files -- spec/*`.split("\n").reject { |f| f.match(%r{^spec/tls/}) }
   s.require_paths = ["lib"]
 end


### PR DESCRIPTION
Seem to `s.test_files` is already redundant and has been deleted from many other gems rubygems/rubygems#735

By removing test files from the gem, it becomes three times lighter (from 159Kb to 54Kb)
It will also stop annoying image screening tools for containing private keys from `spec/tls` folder.




