### PR TITLE
Fix non bang merge

### DIFF
--- a/lib/bunny/queue.rb
+++ b/lib/bunny/queue.rb
@@ -63,7 +63,7 @@ module Bunny
       @type             = @options[:type]
 
       @arguments        = if @type and !@type.empty? then
-        (@options[:arguments] || {}).merge({XArgs::QUEUE_TYPE => @type})
+        (@options[:arguments] || {}).merge!({XArgs::QUEUE_TYPE => @type})
       else
         @options[:arguments]
       end


### PR DESCRIPTION
A quorum queue can't be created because the `x-queue-type` argument isn't merged into `@options[:arguments]`