### PR TITLE
Update queue options[:argument] before declaration

### DIFF
--- a/lib/bunny/queue.rb
+++ b/lib/bunny/queue.rb
@@ -68,6 +68,9 @@ module Bunny
         @options[:arguments]
       end
       verify_type!(@arguments)
+      # reassigns updated and verified arguments because Bunny::Channel#declare_queue
+      # accepts a map of options
+      @options[:arguments] = @arguments
 
       @bindings         = Array.new
 


### PR DESCRIPTION
Since Bunny::Queue#declare! relies on Bunny::Channel#declare_queue which accepts an options hash, not individual properties and x-arguments separately.

Closes #650, originally suggested by @rene-muehlboeck in #649.