### PR TITLE
Correct base OpenSSL exception class in modern Rubies

### DIFF
--- a/lib/bunny/reader_loop.rb
+++ b/lib/bunny/reader_loop.rb
@@ -38,7 +38,7 @@ module Bunny
           break if @mutex.synchronize { @stopping || @stopped || @network_is_down }
           run_once
         rescue AMQ::Protocol::EmptyResponseError, IOError, SystemCallError, Timeout::Error,
-               OpenSSL::OpenSSLError => e
+            OpenSSL::SSL::SSLError => e
           break if terminate? || @session.closing? || @session.closed?
 
           @network_is_down = true


### PR DESCRIPTION
See #656.