### PR TITLE
issue656 - change recoverable_network_failure? 

### DIFF
--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -71,7 +71,7 @@ module Bunny
     # Default reconnection interval for TCP connection failures
     DEFAULT_NETWORK_RECOVERY_INTERVAL = 5.0
 
-    DEFAULT_RECOVERABLE_EXCEPTIONS = [TCPConnectionFailedForAllHosts, TCPConnectionFailed, AMQ::Protocol::EmptyResponseError, SystemCallError, Timeout::Error, Bunny::ConnectionLevelException, Bunny::ConnectionClosedError]
+    DEFAULT_RECOVERABLE_EXCEPTIONS = [StandardError, TCPConnectionFailedForAllHosts, TCPConnectionFailed, AMQ::Protocol::EmptyResponseError, SystemCallError, Timeout::Error, Bunny::ConnectionLevelException, Bunny::ConnectionClosedError]
 
     #
     # API

--- a/spec/issues/issue656_spec.rb
+++ b/spec/issues/issue656_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe Bunny::Session do
+  context 'when created' do
+    let(:io) { StringIO.new } # keep test output clear
+
+    def create_session
+      described_class.new(
+        host: 'fake.host',
+        recovery_attempts: 0,
+        connection_timeout: 0,
+        network_recovery_interval: 0,
+        logfile: io,
+        )
+    end
+
+    it 'has default exceptions' do
+      session = create_session
+      expect(session.recoverable_exceptions).to eq(Bunny::Session::DEFAULT_RECOVERABLE_EXCEPTIONS)
+    end
+
+    it 'can override exceptions' do
+      session = create_session
+      session.recoverable_exceptions = [StandardError]
+      expect(session.recoverable_exceptions).to eq([StandardError])
+    end
+
+    it 'can append exceptions' do
+      session = create_session
+      session.recoverable_exceptions << StandardError
+      expect(session.recoverable_exceptions).to eq(Bunny::Session::DEFAULT_RECOVERABLE_EXCEPTIONS.append(StandardError))
+    end
+  end
+
+  context 'when retry attempts have been exhausted' do
+    let(:io) { StringIO.new } # keep test output clear
+
+    def create_session
+      described_class.new(
+        host: 'fake.host',
+        recovery_attempts: 0,
+        connection_timeout: 0,
+        network_recovery_interval: 0,
+        logfile: io,
+      )
+    end
+
+    it 'closes the session' do
+      session = create_session
+      session.handle_network_failure(StandardError.new)
+      expect(session.closed?).to be true
+    end
+
+    it 'stops the reader loop' do
+      session = create_session
+      reader_loop = session.reader_loop
+      session.handle_network_failure(StandardError.new)
+      expect(reader_loop.stopping?).to be true
+    end
+  end
+end


### PR DESCRIPTION
Alter recoverable_network_failure? to check against a definable array of exceptions and modify recover_from_network_failure to handle the exception logic differently