### PR TITLE
Ruby 3.2 compatibility for 0.7.x stable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ group :development do
 end
 
 group :test do
-  gem "rspec", "~> 3.6.0"
+  gem "rspec"
 end
 
 gemspec

--- a/lib/qrack/client.rb
+++ b/lib/qrack/client.rb
@@ -52,7 +52,7 @@ module Qrack
       @verify_ssl = opts[:verify_ssl].nil? || opts[:verify_ssl]
       @status = :not_connected
       @frame_max = opts[:frame_max] || 131072
-      @channel_max = opts[:channel_max] || 0
+      @channel_max = opts[:channel_max] || 2047
       @heartbeat = opts[:heartbeat] || 0
       @connect_timeout = opts[:connect_timeout] || CONNECT_TIMEOUT
       @read_write_timeout = opts[:socket_timeout]

--- a/lib/qrack/transport/buffer08.rb
+++ b/lib/qrack/transport/buffer08.rb
@@ -194,7 +194,7 @@ module Qrack
                              when String
                                table.write(:octet, 83) # 'S'
                                table.write(:longstr, value.to_s)
-                             when Fixnum
+                             when Integer
                                table.write(:octet, 73) # 'I'
                                table.write(:long, value)
                              when Float

--- a/lib/qrack/transport/buffer09.rb
+++ b/lib/qrack/transport/buffer09.rb
@@ -194,7 +194,7 @@ module Qrack
                              when String
                                table.write(:octet, 83) # 'S'
                                table.write(:longstr, value.to_s)
-                             when Fixnum
+                             when Integer
                                table.write(:octet, 73) # 'I'
                                table.write(:long, value)
                              when Float

--- a/spec/spec_08/bunny_spec.rb
+++ b/spec/spec_08/bunny_spec.rb
@@ -8,7 +8,7 @@
 # If this is not the case, please change the 'Bunny.new' call below to include
 # the relevant arguments e.g. @b = Bunny.new(:user => 'john', :pass => 'doe', :host => 'foobar')
 
-require File.expand_path(File.join(File.dirname(__FILE__), %w[.. .. lib bunny]))
+require_relative "../spec_helper"
 
 describe Bunny do
 

--- a/spec/spec_08/connection_spec.rb
+++ b/spec/spec_08/connection_spec.rb
@@ -2,7 +2,7 @@
 
 # connection_spec.rb
 
-require File.expand_path(File.join(File.dirname(__FILE__), %w[.. .. lib bunny]))
+require_relative "../spec_helper"
 
 describe Bunny do
 

--- a/spec/spec_08/exchange_spec.rb
+++ b/spec/spec_08/exchange_spec.rb
@@ -8,7 +8,7 @@
 # If this is not the case, please change the 'Bunny.new' call below to include
 # the relevant arguments e.g. @b = Bunny.new(:user => 'john', :pass => 'doe', :host => 'foobar')
 
-require File.expand_path(File.join(File.dirname(__FILE__), %w[.. .. lib bunny]))
+require_relative "../spec_helper"
 
 describe 'Exchange' do
 

--- a/spec/spec_08/exchange_spec.rb
+++ b/spec/spec_08/exchange_spec.rb
@@ -135,6 +135,11 @@ describe 'Exchange' do
     opts.should == {:key => 'a', :persistent => true}
   end
 
+  it "should be able to publish a message with headers containing integer values" do
+    exch = @b.exchange('direct_exchange')
+    exch.publish('This is a published message', :headers => {:a => 1})
+  end
+
   it "should be able to return an undeliverable message" do
     exch = @b.exchange('return_exch')
     exch.publish('This message should be undeliverable', :mandatory => true)

--- a/spec/spec_08/queue_spec.rb
+++ b/spec/spec_08/queue_spec.rb
@@ -8,12 +8,12 @@
 # If this is not the case, please change the 'Bunny.new' call below to include
 # the relevant arguments e.g. @b = Bunny.new(:user => 'john', :pass => 'doe', :host => 'foobar')
 
-require File.expand_path(File.join(File.dirname(__FILE__), %w[.. .. lib bunny]))
+require_relative "../spec_helper"
 
 describe 'Queue' do
 
   def expect_deprecation_warning_for_publishing_on_queue(q, n=1)
-    Bunny.should_receive(:deprecation_warning).with("Qrack::Queue#publish", "0.8", anything).exactly(n).times
+    expect(Bunny).to receive(:deprecation_warning).with("Qrack::Queue#publish", "0.8", anything).exactly(n).times
   end
 
   def message_count(queue, sleep_time = 0.1)

--- a/spec/spec_09/amqp_url_spec.rb
+++ b/spec/spec_09/amqp_url_spec.rb
@@ -6,7 +6,7 @@
 # If this is not the case, please change the 'Bunny.new' call below to include
 # the relevant arguments e.g. @b = Bunny.new(:user => 'john', :pass => 'doe', :host => 'foobar')
 
-require "bunny"
+require_relative "../spec_helper"
 
 describe Bunny do
   context "AMQP URL parsing" do

--- a/spec/spec_09/bunny_spec.rb
+++ b/spec/spec_09/bunny_spec.rb
@@ -8,7 +8,7 @@
 # If this is not the case, please change the 'Bunny.new' call below to include
 # the relevant arguments e.g. @b = Bunny.new(:user => 'john', :pass => 'doe', :host => 'foobar')
 
-require "bunny"
+require_relative "../spec_helper"
 
 describe Bunny do
 

--- a/spec/spec_09/connection_spec.rb
+++ b/spec/spec_09/connection_spec.rb
@@ -2,7 +2,7 @@
 
 # connection_spec.rb
 
-require "bunny"
+require_relative "../spec_helper"
 
 describe Bunny do
 

--- a/spec/spec_09/exchange_spec.rb
+++ b/spec/spec_09/exchange_spec.rb
@@ -8,7 +8,7 @@
 # If this is not the case, please change the 'Bunny.new' call below to include
 # the relevant arguments e.g. @b = Bunny.new(:user => 'john', :pass => 'doe', :host => 'foobar')
 
-require "bunny"
+require_relative "../spec_helper"
 
 describe 'Exchange' do
 

--- a/spec/spec_09/exchange_spec.rb
+++ b/spec/spec_09/exchange_spec.rb
@@ -128,6 +128,11 @@ describe 'Exchange' do
     exch.publish('This is a published message')
   end
 
+  it "should be able to publish a message with headers containing integer values" do
+    exch = @b.exchange('direct_exchange')
+    exch.publish('This is a published message', :headers => {:a => 1})
+  end
+
   it "should not modify the passed options hash when publishing a message" do
     exch = @b.exchange('direct_exchange')
     opts = {:key => 'a', :persistent => true}

--- a/spec/spec_09/queue_spec.rb
+++ b/spec/spec_09/queue_spec.rb
@@ -8,7 +8,7 @@
 # If this is not the case, please change the 'Bunny.new' call below to include
 # the relevant arguments e.g. @b = Bunny.new(:user => 'john', :pass => 'doe', :host => 'foobar')
 
-require "bunny"
+require_relative "../spec_helper"
 
 describe 'Queue' do
 


### PR DESCRIPTION
We're still stuck on this old branch, but want to use ruby 3.2.

Are you OK with releasing a new 0.7.x version?
