### PR TITLE
Update consumer_work_pool.rb

### DIFF
--- a/lib/bunny/consumer_work_pool.rb
+++ b/lib/bunny/consumer_work_pool.rb
@@ -70,7 +70,7 @@ module Bunny
       return if !(wait_for_workers && @shutdown_timeout && was_running)
 
       @shutdown_mutex.synchronize do
-        @shutdown_conditional.wait(@shutdown_mutex, @shutdown_timeout)
+        @shutdown_conditional.wait(@shutdown_mutex, @shutdown_timeout) if busy?
       end
     end
 


### PR DESCRIPTION
Fix waiting for shutdown when pool is already shutdown

threads may terminate and call shutdown_conditional.signal before  shutdown_conditional.wait. With this fix we check if queue is empty so there is no point in waiting.