### PR TITLE
Introduce recovery_failed callback

### DIFF
--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -128,7 +128,7 @@ module Bunny
     # @option connection_string_or_opts [Integer] :reset_recovery_attempts_after_reconnection (true) Should recovery attempt counter be reset after successful reconnection? When set to false, the attempt counter will last through the entire lifetime of the connection object.
     # @option connection_string_or_opts [Proc] :recovery_attempt_started (nil) Will be called before every connection recovery attempt
     # @option connection_string_or_opts [Proc] :recovery_completed (nil) Will be called after successful connection recovery
-    # @option connection_string_or_opts [Proc] :recovery_failed (nil) Will be called when the connection recovery failed after the specified amount of recovery attempts
+    # @option connection_string_or_opts [Proc] :recovery_attempts_exhausted (nil) Will be called when the connection recovery failed after the specified amount of recovery attempts
     # @option connection_string_or_opts [Boolean] :recover_from_connection_close (true) Should this connection recover after receiving a server-sent connection.close (e.g. connection was force closed)?
     # @option connection_string_or_opts [Object] :session_error_handler (Thread.current) Object which responds to #raise that will act as a session error handler. Defaults to Thread.current, which will raise asynchronous exceptions in the thread that created the session.
     #
@@ -226,7 +226,7 @@ module Bunny
 
       @recovery_attempt_started = opts[:recovery_attempt_started]
       @recovery_completed       = opts[:recovery_completed]
-      @recovery_failed          = opts[:recovery_failed]
+      @recovery_attempts_exhausted          = opts[:recovery_attempts_exhausted]
 
       @session_error_handler = opts.fetch(:session_error_handler, Thread.current)
 
@@ -558,8 +558,8 @@ module Bunny
     # Defines a callable (e.g. a block) that will be called
     # when the connection recovery failed after the specified
     # numbers of recovery attempts.
-    def after_recovery_failed(&block)
-      @recovery_failed = block
+    def after_recovery_attempts_exhausted(&block)
+      @recovery_attempts_exhausted = block
     end
 
     #
@@ -817,7 +817,7 @@ module Bunny
           @transport.close
           self.close(false)
           @manually_closed = false
-          notify_of_recovery_failed
+          notify_of_recovery_attempts_exhausted
         end
       else
         raise e
@@ -869,8 +869,8 @@ module Bunny
     end
 
     # @private
-    def notify_of_recovery_failed
-      @recovery_failed.call if @recovery_failed
+    def notify_of_recovery_attempts_exhausted
+      @recovery_attempts_exhausted.call if @recovery_attempts_exhausted
     end
 
     # @private

--- a/spec/higher_level_api/integration/toxiproxy_spec.rb
+++ b/spec/higher_level_api/integration/toxiproxy_spec.rb
@@ -48,11 +48,13 @@ if ::Toxiproxy.running?
     end
 
     context "recovery attempt limit that's exceeded" do
+      let(:dummy) { double(call: true) }
+
       before(:each) do
         setup_toxiproxy
         @connection = Bunny.new(user: "bunny_gem", password: "bunny_password", vhost: "bunny_testbed",
           host: "localhost:11111", heartbeat_timeout: 1, automatically_recover: true, network_recovery_interval: 1,
-          recovery_attempts: 2, reset_recovery_attempts_after_reconnection: true,
+          recovery_attempts: 2, recovery_failed: Proc.new { dummy.call }, reset_recovery_attempts_after_reconnection: true,
           disconnect_timeout: 1)
         @connection.start
       end
@@ -68,6 +70,7 @@ if ::Toxiproxy.running?
 
         expect(@connection.open?).to be(false)
         expect(@connection.closed?).to be(true)
+        expect(dummy).to have_received(:call).once
       end
     end # context
   end # describe

--- a/spec/higher_level_api/integration/toxiproxy_spec.rb
+++ b/spec/higher_level_api/integration/toxiproxy_spec.rb
@@ -54,7 +54,7 @@ if ::Toxiproxy.running?
         setup_toxiproxy
         @connection = Bunny.new(user: "bunny_gem", password: "bunny_password", vhost: "bunny_testbed",
           host: "localhost:11111", heartbeat_timeout: 1, automatically_recover: true, network_recovery_interval: 1,
-          recovery_attempts: 2, recovery_failed: Proc.new { dummy.call }, reset_recovery_attempts_after_reconnection: true,
+          recovery_attempts: 2, recovery_attempts_exhausted: Proc.new { dummy.call }, reset_recovery_attempts_after_reconnection: true,
           disconnect_timeout: 1)
         @connection.start
       end


### PR DESCRIPTION
It’s possible to specify the recovery_attempts option on the Bunny::Session. 
Hitting the recovery attempts limit without a successful recovery leads to a cleanup of connection, etc.
However, the client is not informed about this state and has no chance to react upon it.

This PR introduces a callback which is executed in exactly the above described situation enabling client code to react to a failed recovery process.

Relates to: https://github.com/ruby-amqp/bunny/issues/665