### PR TITLE
Fix exception on heartbeat sender

### DIFF
--- a/lib/bunny/heartbeat_sender.rb
+++ b/lib/bunny/heartbeat_sender.rb
@@ -53,7 +53,7 @@ module Bunny
       rescue IOError => ioe
         @logger.error "I/O error in the hearbeat sender: #{ioe.message}"
         stop
-      rescue Exception => e
+      rescue ::Exception => e
         @logger.error "Error in the hearbeat sender: #{e.message}"
         stop
       end

--- a/spec/unit/heartbeat_sender_spec.rb
+++ b/spec/unit/heartbeat_sender_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+describe Bunny::HeartbeatSender do
+  let(:transport) { instance_double("Bunny::Transport") }
+
+  # let(:logger) { StringIO.new } # keep test output clear
+  let(:logger) { Logger.new(STDOUT) }
+
+  let(:heartbeat_sender) do
+    allow(Bunny::Transport).to receive(:new).and_return(transport)
+    described_class.new(Bunny::Transport.new, logger)
+  end
+
+  it "raises an error when standard error is raised" do
+    allow(logger).to receive(:error)
+    # This simulates a transport that raises an error.
+    allow(heartbeat_sender).to receive(:beat).and_raise(StandardError.new("This error should be logged"))
+
+    heartbeat_sender.start
+    expect(logger).to have_received(:error).with("Error in the hearbeat sender: This error should be logged")
+  end
+end


### PR DESCRIPTION
Why?
This was introduced in:
https://github.com/ruby-amqp/bunny/commit/55d57e38a31ae787d8693fe6b6acbe0ccd515653
But due to change in:
https://github.com/ruby-amqp/bunny/commit/c85c24bc1210e028276d32994e9753b474d6f674
We lost logging of standard errors.
It is