### PR TITLE
Fix documentation and typos

### DIFF
--- a/lib/bunny.rb
+++ b/lib/bunny.rb
@@ -64,7 +64,7 @@ module Bunny
   # @option connection_string_or_opts [String] :password ("guest") Password
   # @option connection_string_or_opts [String] :vhost ("/") Virtual host to use
   # @option connection_string_or_opts [Integer, Symbol] :heartbeat (:server) Heartbeat timeout to offer to the server. :server means use the value suggested by RabbitMQ. 0 means heartbeats and socket read timeouts will be disabled (not recommended).
-  # @option connection_string_or_opts [Integer] :network_recovery_interval (5) Recovery interval periodic network recovery will use. This includes initial pause after network failure.
+  # @option connection_string_or_opts [Float] :network_recovery_interval (5.0) Recovery interval periodic network recovery will use. This includes initial pause after network failure.
   # @option connection_string_or_opts [Boolean] :tls (false) Should TLS/SSL be used?
   # @option connection_string_or_opts [String] :tls_cert (nil) Path to client TLS/SSL certificate file (.pem)
   # @option connection_string_or_opts [String] :tls_key (nil) Path to client TLS/SSL private key file (.pem)

--- a/lib/bunny.rb
+++ b/lib/bunny.rb
@@ -84,7 +84,7 @@ module Bunny
   # @option connection_string_or_opts [Integer] :log_level The log level to use when creating a logger.  Defaults to LOGGER::WARN
   # @option connection_string_or_opts [Boolean] :automatically_recover (true) Should automatically recover from network failures?
   # @option connection_string_or_opts [Integer] :recovery_attempts (nil) Max number of recovery attempts, nil means forever
-  # @option connection_string_or_opts [Integer] :reset_recovery_attempts_after_reconnection (true) Should recovery attempt counter be reset after successful reconnection? When set to false, the attempt counter will last through the entire lifetime of the connection object.
+  # @option connection_string_or_opts [Boolean] :reset_recovery_attempts_after_reconnection (true) Should recovery attempt counter be reset after successful reconnection? When set to false, the attempt counter will last through the entire lifetime of the connection object.
   # @option connection_string_or_opts [Proc] :recovery_attempt_started (nil) Will be called before every connection recovery attempt
   # @option connection_string_or_opts [Proc] :recovery_completed (nil) Will be called after successful connection recovery
   # @option connection_string_or_opts [Boolean] :recover_from_connection_close (true) Should this connection recover after receiving a server-sent connection.close (e.g. connection was force closed)?

--- a/lib/bunny.rb
+++ b/lib/bunny.rb
@@ -64,7 +64,7 @@ module Bunny
   # @option connection_string_or_opts [String] :password ("guest") Password
   # @option connection_string_or_opts [String] :vhost ("/") Virtual host to use
   # @option connection_string_or_opts [Integer, Symbol] :heartbeat (:server) Heartbeat timeout to offer to the server. :server means use the value suggested by RabbitMQ. 0 means heartbeats and socket read timeouts will be disabled (not recommended).
-  # @option connection_string_or_opts [Integer] :network_recovery_interval (4) Recovery interval periodic network recovery will use. This includes initial pause after network failure.
+  # @option connection_string_or_opts [Integer] :network_recovery_interval (5) Recovery interval periodic network recovery will use. This includes initial pause after network failure.
   # @option connection_string_or_opts [Boolean] :tls (false) Should TLS/SSL be used?
   # @option connection_string_or_opts [String] :tls_cert (nil) Path to client TLS/SSL certificate file (.pem)
   # @option connection_string_or_opts [String] :tls_key (nil) Path to client TLS/SSL private key file (.pem)

--- a/lib/bunny/heartbeat_sender.rb
+++ b/lib/bunny/heartbeat_sender.rb
@@ -51,10 +51,10 @@ module Bunny
           sleep @interval
         end
       rescue IOError => ioe
-        @logger.error "I/O error in the hearbeat sender: #{ioe.message}"
+        @logger.error "I/O error in the heartbeat sender: #{ioe.message}"
         stop
       rescue ::Exception => e
-        @logger.error "Error in the hearbeat sender: #{e.message}"
+        @logger.error "Error in the heartbeat sender: #{e.message}"
         stop
       end
     end

--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -125,7 +125,7 @@ module Bunny
     # @option connection_string_or_opts [Integer] :log_level The log level to use when creating a logger.  Defaults to LOGGER::WARN
     # @option connection_string_or_opts [Boolean] :automatically_recover (true) Should automatically recover from network failures?
     # @option connection_string_or_opts [Integer] :recovery_attempts (nil) Max number of recovery attempts, nil means forever
-    # @option connection_string_or_opts [Integer] :reset_recovery_attempts_after_reconnection (true) Should recovery attempt counter be reset after successful reconnection? When set to false, the attempt counter will last through the entire lifetime of the connection object.
+    # @option connection_string_or_opts [Boolean] :reset_recovery_attempts_after_reconnection (true) Should recovery attempt counter be reset after successful reconnection? When set to false, the attempt counter will last through the entire lifetime of the connection object.
     # @option connection_string_or_opts [Proc] :recovery_attempt_started (nil) Will be called before every connection recovery attempt
     # @option connection_string_or_opts [Proc] :recovery_completed (nil) Will be called after successful connection recovery
     # @option connection_string_or_opts [Proc] :recovery_attempts_exhausted (nil) Will be called when the connection recovery failed after the specified amount of recovery attempts

--- a/spec/unit/heartbeat_sender_spec.rb
+++ b/spec/unit/heartbeat_sender_spec.rb
@@ -17,6 +17,6 @@ describe Bunny::HeartbeatSender do
     allow(heartbeat_sender).to receive(:beat).and_raise(StandardError.new("This error should be logged"))
 
     heartbeat_sender.start
-    expect(logger).to have_received(:error).with("Error in the hearbeat sender: This error should be logged")
+    expect(logger).to have_received(:error).with("Error in the heartbeat sender: This error should be logged")
   end
 end


### PR DESCRIPTION
Update `reset_recovery_attempts_after_reconnection` to be documented as a Boolean type, and fix various typos of the word "heartbeat" that appear as "hearbeat".

- [ ] TODO: Run tests in [contributing guidelines](https://github.com/ruby-amqp/bunny/blob/8b700a00b62d4f887f53d4871f019d6d494c5f4d/CONTRIBUTING.md)