### PR TITLE
Channel callback from delivery acknowledgement timeout

### DIFF
--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -1820,7 +1820,7 @@ module Bunny
 
     # @private
     def channel_level_exception_after_operation_that_has_no_response?(method)
-      method.reply_code == 406 && method.reply_text =~ /unknown delivery tag/
+      method.reply_code == 406 && (method.reply_text =~ /unknown delivery tag/ || method.reply_text =~ /delivery acknowledgement on channel \d+ timed out/)
     end
 
     # @private


### PR DESCRIPTION
Add delivery acknowledgement timeout as a condition to trigger the on_error handler to be notified during a channel closure with a 406.

related to discussion https://github.com/ruby-amqp/bunny/discussions/682