### PR TITLE
Update docker-compose setup for tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   rabbitmq:
     build: ./docker

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,18 @@
-FROM ubuntu:18.04
+FROM ubuntu:24.04
 
 RUN apt-get update -y
-RUN apt-get install -y gnupg2 wget
-RUN wget -O - "https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc" | apt-key add -
+RUN apt-get install -y gnupg2 curl locales
+RUN curl -1sLf 'https://keys.openpgp.org/vks/v1/by-fingerprint/0A9AF2115F4687BD29803A206B73A36E6026DFCA' | gpg --dearmor | tee /usr/share/keyrings/com.rabbitmq.team.gpg > /dev/null
+RUN curl -1sLf 'https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-erlang.E495BB49CC4BBE5B.key' | gpg --dearmor | tee /usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg > /dev/null
+RUN curl -1sLf 'https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-server.9F4587F226208342.key' | gpg --dearmor | tee /usr/share/keyrings/rabbitmq.9F4587F226208342.gpg > /dev/null
 
-COPY apt/sources.list.d/bintray.rabbitmq.list /etc/apt/sources.list.d/bintray.rabbitmq.list
-COPY apt/preferences.d/erlang                 /etc/apt/preferences.d/erlang
+# Erlang expects UTF-8
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+COPY apt/sources.list.d/rabbitmq.list /etc/apt/sources.list.d/rabbitmq.list
 
 RUN apt-get update -y && apt-get upgrade -y
 

--- a/docker/apt/preferences.d/erlang
+++ b/docker/apt/preferences.d/erlang
@@ -1,3 +1,0 @@
-Package: erlang*
-Pin: release o=Bintray
-Pin-Priority: 1000

--- a/docker/apt/sources.list.d/bintray.rabbitmq.list
+++ b/docker/apt/sources.list.d/bintray.rabbitmq.list
@@ -1,2 +1,0 @@
-deb http://dl.bintray.com/rabbitmq-erlang/debian bionic erlang
-deb http://dl.bintray.com/rabbitmq/debian bionic main

--- a/docker/apt/sources.list.d/rabbitmq.list
+++ b/docker/apt/sources.list.d/rabbitmq.list
@@ -1,0 +1,17 @@
+## Provides modern Erlang/OTP releases
+##
+deb [arch=amd64 signed-by=/usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg] https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble main
+deb-src [signed-by=/usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg] https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble main
+
+# another mirror for redundancy
+deb [arch=amd64 signed-by=/usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg] https://ppa2.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble main
+deb-src [signed-by=/usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg] https://ppa2.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble main
+
+## Provides RabbitMQ
+##
+deb [arch=amd64 signed-by=/usr/share/keyrings/rabbitmq.9F4587F226208342.gpg] https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-server/deb/ubuntu noble main
+deb-src [signed-by=/usr/share/keyrings/rabbitmq.9F4587F226208342.gpg] https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-server/deb/ubuntu noble main
+
+# another mirror for redundancy
+deb [arch=amd64 signed-by=/usr/share/keyrings/rabbitmq.9F4587F226208342.gpg] https://ppa2.rabbitmq.com/rabbitmq/rabbitmq-server/deb/ubuntu noble main
+deb-src [signed-by=/usr/share/keyrings/rabbitmq.9F4587F226208342.gpg] https://ppa2.rabbitmq.com/rabbitmq/rabbitmq-server/deb/ubuntu noble main

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -7,8 +7,9 @@ echo 'Starting a RabbitMQ node'
 $server -detached
 
 echo "Waiting for RabbitMQ to finish startup..."
+sleep 5
+$ctl await_startup --timeout 30
 
-$ctl await_startup --timeout 15
 
 $ctl add_user bunny_gem bunny_password
 $ctl add_user bunny_reader reader_password


### PR DESCRIPTION
The Bintray repository used in the docker file no longer exists.

This commit updates the Dockerfile to use a recent version of Ubuntu and then follows the guidelines given by the RabbitMQ project for Debian and Ubuntu based distro's.

https://www.rabbitmq.com/docs/install-debian