### PR TITLE
Fix queue_exists? for exclusive queues

### DIFF
--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -516,6 +516,8 @@ module Bunny
       begin
         ch.queue(name, :passive => true)
         true
+      rescue Bunny::ResourceLocked => _
+        true
       rescue Bunny::NotFound => _
         false
       ensure


### PR DESCRIPTION
Queues with the exclusive flag set can't be redeclared, causing a ResourceLocked exception. This solution assumes that if something is locked it also exists.