### PR TITLE
Make compatible with frozen string literals

### DIFF
--- a/lib/amq/protocol/extensions.rb
+++ b/lib/amq/protocol/extensions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # @private
 module AMQ
   # @private

--- a/lib/bunny.rb
+++ b/lib/bunny.rb
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8; mode: ruby -*-
+# frozen_string_literal: true
 
 require "timeout"
 

--- a/lib/bunny/authentication/credentials_encoder.rb
+++ b/lib/bunny/authentication/credentials_encoder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Bunny
   # Contains credentials encoding implementations for various
   # authentication strategies.

--- a/lib/bunny/authentication/external_mechanism_encoder.rb
+++ b/lib/bunny/authentication/external_mechanism_encoder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bunny/authentication/credentials_encoder"
 
 module Bunny

--- a/lib/bunny/authentication/plain_mechanism_encoder.rb
+++ b/lib/bunny/authentication/plain_mechanism_encoder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bunny/authentication/credentials_encoder"
 
 module Bunny

--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
+
 require "thread"
 require "monitor"
 require "set"

--- a/lib/bunny/channel_id_allocator.rb
+++ b/lib/bunny/channel_id_allocator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "thread"
 require "monitor"
 require "amq/int_allocator"

--- a/lib/bunny/concurrent/atomic_fixnum.rb
+++ b/lib/bunny/concurrent/atomic_fixnum.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "set"
 require "thread"
 require "monitor"

--- a/lib/bunny/concurrent/condition.rb
+++ b/lib/bunny/concurrent/condition.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "thread"
 require "monitor"
 

--- a/lib/bunny/concurrent/continuation_queue.rb
+++ b/lib/bunny/concurrent/continuation_queue.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "thread"
 
 module Bunny

--- a/lib/bunny/concurrent/linked_continuation_queue.rb
+++ b/lib/bunny/concurrent/linked_continuation_queue.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if !defined?(JRUBY_VERSION)
   raise "Bunny::Concurrent::LinkedContinuationQueue can only be used on JRuby!"
 end

--- a/lib/bunny/concurrent/synchronized_sorted_set.rb
+++ b/lib/bunny/concurrent/synchronized_sorted_set.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "set"
 require "thread"
 

--- a/lib/bunny/consumer.rb
+++ b/lib/bunny/consumer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Bunny
   # Base class that represents consumer interface. Subclasses of this class implement
   # specific logic of handling consumer life cycle events. Note that when the only event

--- a/lib/bunny/consumer_tag_generator.rb
+++ b/lib/bunny/consumer_tag_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Bunny
   # Used to generate consumer tags in the client
   class ConsumerTagGenerator

--- a/lib/bunny/consumer_work_pool.rb
+++ b/lib/bunny/consumer_work_pool.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "thread"
 
 module Bunny

--- a/lib/bunny/cruby/socket.rb
+++ b/lib/bunny/cruby/socket.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "socket"
 
 module Bunny
@@ -52,7 +54,7 @@ module Bunny
     def read_fully(count, timeout = nil)
       return nil if @__bunny_socket_eof_flag__
 
-      value = ''
+      value = +''
       begin
         loop do
           value << read_nonblock(count - value.bytesize)

--- a/lib/bunny/cruby/ssl_socket.rb
+++ b/lib/bunny/cruby/ssl_socket.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "socket"
 
 module Bunny
@@ -39,7 +41,7 @@ module Bunny
       def read_fully(count, timeout = nil)
         return nil if @__bunny_socket_eof_flag__
 
-        value = ''
+        value = +''
         begin
           loop do
             value << read_nonblock(count - value.bytesize)

--- a/lib/bunny/delivery_info.rb
+++ b/lib/bunny/delivery_info.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bunny/versioned_delivery_tag"
 
 module Bunny

--- a/lib/bunny/exceptions.rb
+++ b/lib/bunny/exceptions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Bunny
   # Base class for all Bunny exceptions
   # @api public

--- a/lib/bunny/exchange.rb
+++ b/lib/bunny/exchange.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'amq/protocol'
 
 module Bunny

--- a/lib/bunny/framing.rb
+++ b/lib/bunny/framing.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Bunny
   # @private
   module Framing

--- a/lib/bunny/get_response.rb
+++ b/lib/bunny/get_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bunny/versioned_delivery_tag"
 
 module Bunny

--- a/lib/bunny/heartbeat_sender.rb
+++ b/lib/bunny/heartbeat_sender.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "thread"
 require "amq/protocol/client"
 require "amq/protocol/frame"

--- a/lib/bunny/jruby/socket.rb
+++ b/lib/bunny/jruby/socket.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bunny/cruby/socket"
 
 module Bunny
@@ -30,7 +32,7 @@ module Bunny
       # @return [String] Data read from the socket
       # @api public
       def read_fully(count, timeout = nil)
-        value = ''
+        value = +''
 
         begin
           loop do

--- a/lib/bunny/jruby/ssl_socket.rb
+++ b/lib/bunny/jruby/ssl_socket.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Bunny
   module JRuby
     begin
@@ -23,7 +25,7 @@ module Bunny
         def read_fully(count, timeout = nil)
           return nil if @__bunny_socket_eof_flag__
 
-          value = ''
+          value = +''
           begin
             loop do
               value << read_nonblock(count - value.bytesize)

--- a/lib/bunny/message_properties.rb
+++ b/lib/bunny/message_properties.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Bunny
   # Wraps basic properties hash as returned by amq-protocol to
   # provide access to the delivery properties as immutable hash as

--- a/lib/bunny/queue.rb
+++ b/lib/bunny/queue.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bunny/get_response"
 
 module Bunny

--- a/lib/bunny/reader_loop.rb
+++ b/lib/bunny/reader_loop.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "thread"
 
 module Bunny
@@ -76,7 +78,7 @@ module Bunny
 
       if !frame.final? || frame.method_class.has_content?
         header   = @transport.read_next_frame
-        content  = ''
+        content  = +''
 
         if header.body_size > 0
           loop do

--- a/lib/bunny/return_info.rb
+++ b/lib/bunny/return_info.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Bunny
   # Wraps AMQ::Protocol::Basic::Return to
   # provide access to the delivery properties as immutable hash as

--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "socket"
 require "thread"
 require "monitor"
@@ -1161,7 +1163,7 @@ module Bunny
       channel.synchronize do
         # see rabbitmq/rabbitmq-server#156
         if open?
-          data = frames.reduce("") { |acc, frame| acc << frame.encode }
+          data = frames.reduce(+"") { |acc, frame| acc << frame.encode }
           @transport.write(data)
           signal_activity!
         else

--- a/lib/bunny/socket.rb
+++ b/lib/bunny/socket.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # See #165. MK.
 if defined?(JRUBY_VERSION)
   require "bunny/jruby/socket"

--- a/lib/bunny/ssl_socket.rb
+++ b/lib/bunny/ssl_socket.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # See #165. MK.
 if defined?(JRUBY_VERSION)
   require "bunny/jruby/ssl_socket"

--- a/lib/bunny/test_kit.rb
+++ b/lib/bunny/test_kit.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 
 require "timeout"
 

--- a/lib/bunny/timeout.rb
+++ b/lib/bunny/timeout.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Bunny
   Timeout = ::Timeout
 

--- a/lib/bunny/timestamp.rb
+++ b/lib/bunny/timestamp.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Bunny
   # Abstracts away the Ruby (OS) method of retriving timestamps.
   #

--- a/lib/bunny/transport.rb
+++ b/lib/bunny/transport.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "socket"
 require "thread"
 require "monitor"

--- a/lib/bunny/version.rb
+++ b/lib/bunny/version.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 module Bunny
   # @return [String] Version of the library

--- a/lib/bunny/versioned_delivery_tag.rb
+++ b/lib/bunny/versioned_delivery_tag.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Bunny
   # Wraps a delivery tag (which is an integer) so that {Bunny::Channel} could
   # detect stale tags after connection recovery.


### PR DESCRIPTION
Closes #695

I added the magic comment to opt in to frozen string literals already and fixed the problems that appeared.

`+""` returns a non-frozen string.