### PR TITLE
Fix for 2 typos in the documentation

### DIFF
--- a/docs/guides/exchanges.md
+++ b/docs/guides/exchanges.md
@@ -555,7 +555,7 @@ used.
 ## Checking if an Exchange Exists
 
 Sometimes it's convenient to check if an exchange exists. To do so, at the protocol
-level you use `exchange.declare` with `passive` seto to `true`. In response
+level you use `exchange.declare` with `passive` sets to `true`. In response
 RabbitMQ responds with a channel exception if the exchange does not exist.
 
 Bunny provides a convenience method, `Bunny::Session#exchange_exists?`, to do this:

--- a/docs/guides/queues.md
+++ b/docs/guides/queues.md
@@ -1087,7 +1087,7 @@ Exchanges](/articles/exchanges.html) guide. In this guide, we will
 only mention how message acknowledgements are related to AMQP
 transactions and the Publisher Confirms extension.
 
-Let us consider a publisher application (P) that communications with a
+Let us consider a publisher application (P) that communicates with a
 consumer (C) using AMQP 0.9.1. Their communication can be graphically
 represented like this:
 


### PR DESCRIPTION
Hi bunny team 👋🏾 

This PR fixes 2 typos I found in the documentation while reading it.

Let me know if this is not where to fix typos in the documentation.