### PR TITLE
Handle EBADF together with other SystemCallErrors

### DIFF
--- a/spec/higher_level_api/integration/connection_recovery_spec.rb
+++ b/spec/higher_level_api/integration/connection_recovery_spec.rb
@@ -181,17 +181,13 @@ describe "Connection recovery" do
     with_open do |c|
       ch = c.create_channel
       q  = ch.queue("", exclusive: true)
-      old_name = q.name
 
       close_all_connections!
       wait_for_recovery_with { connections.any? }
       expect(ch).to be_open
 
-      expect(q.name).to_not be ==(old_name)
-
-      # queue name has changed
+      expect(q).to be_server_named
       expect(c.topology_registry.queues.size).to eq 1
-      expect(c.topology_registry.queues[old_name]).to be(nil)
 
       ensure_queue_recovery(ch, q)
 


### PR DESCRIPTION
References https://github.com/ruby-amqp/bunny/discussions/715.

This combines both handlers into one that

 * Sets a value that will terminate the next loop
 * Tells the `Bunny::Session` parent to begin connection recovery