### PR TITLE
Fixes broken link for JRuby March Hare to GitHub repo, url offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ For environments that use TLS, Bunny expects Ruby installations to use a recent 
 
 Bunny no longer supports JRuby.
 
-JRuby users should use [March Hare](http://rubymarchhare.info), which has a similar API
+JRuby users should use [March Hare](https://github.com/ruby-amqp/march_hare), which has a similar API
 and is built on top of the RabbitMQ Java client specifically for JRuby.
 
 


### PR DESCRIPTION
No CI and specs, because it is just an improvement to the docs.