### PR TITLE
Ruby 3.0 modernisation, code quality improvements, and gem cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,46 +1,7 @@
-# encoding: utf-8
-
 source "https://rubygems.org"
-
-# Use local clones if possible.
-# If you want to use your local copy, just symlink it to vendor.
-# See http://blog.101ideas.cz/posts/custom-gems-in-gemfile.html
-extend Module.new {
-  def gem(name, *args)
-    options = args.last.is_a?(Hash) ? args.last : Hash.new
-
-    local_path = File.expand_path("../vendor/#{name}", __FILE__)
-    if File.exist?(local_path)
-      super name, options.merge(path: local_path).
-        delete_if { |key, _| [:git, :branch].include?(key) }
-    else
-      super name, *args
-    end
-  end
-}
-
-gem "rake", ">= 12.3.1"
-
-group :development do
-  gem "yard"
-
-  gem "redcarpet", platform: :mri
-  gem "ruby-prof", platform: :mri
-end
-
-group :test do
-  gem "rspec", "~> 3.13.0"
-  gem "rspec-retry", "~> 0.6"
-  gem "sorted_set", '~> 1', '>= 1.0.2'
-  gem "base64"
-  gem "rabbitmq_http_api_client", "~> 3.2.0", require: "rabbitmq/http/client"
-  gem "toxiproxy", "~> 2"
-end
 
 gemspec
 
-# Use local clones if possible.
-# If you want to use your local copy, just symlink it to vendor.
 def custom_gem(name, *args)
   options = args.last.is_a?(Hash) ? args.pop : {}
   local_path = File.expand_path("../vendor/#{name}", __FILE__)
@@ -52,4 +13,22 @@ def custom_gem(name, *args)
   end
 end
 
-custom_gem "amq-protocol", "~> 2.6"
+custom_gem "amq-protocol", "~> 2.7"
+
+gem "rake", ">= 12.3.1"
+
+group :development do
+  gem "yard"
+  gem "redcarpet", platform: :mri
+  gem "ruby-prof", platform: :mri
+  gem "benchmark"
+end
+
+group :test do
+  gem "rspec", "~> 3.13"
+  gem "rspec-retry", "~> 0.6"
+  gem "sorted_set", "~> 1", ">= 1.0.2"
+  gem "base64"
+  gem "rabbitmq_http_api_client", "~> 3.2", require: "rabbitmq/http/client"
+  gem "toxiproxy", "~> 2"
+end

--- a/benchmarks/mutex_and_monitor.rb
+++ b/benchmarks/mutex_and_monitor.rb
@@ -3,9 +3,7 @@
 
 require "rubygems"
 require "set"
-require "thread"
 require "benchmark"
-require "monitor"
 
 puts
 puts "-" * 80

--- a/benchmarks/synchronized_sorted_set.rb
+++ b/benchmarks/synchronized_sorted_set.rb
@@ -3,7 +3,6 @@
 
 require "rubygems"
 require "sorted_set"
-require "thread"
 require "benchmark"
 
 require "bunny/concurrent/synchronized_sorted_set"

--- a/bunny.gemspec
+++ b/bunny.gemspec
@@ -1,39 +1,34 @@
-#!/usr/bin/env gem build
-# encoding: utf-8
-
-require File.expand_path("../lib/bunny/version", __FILE__)
+require_relative "lib/bunny/version"
 
 Gem::Specification.new do |s|
   s.name = "bunny"
-  s.version = Bunny::VERSION.dup
+  s.version = Bunny::VERSION
   s.homepage = "http://rubybunny.info"
   s.summary = "Popular easy to use Ruby client for RabbitMQ"
   s.description = "Easy to use, feature complete Ruby client for RabbitMQ 3.9 and later versions."
   s.license = "MIT"
-  s.required_ruby_version = Gem::Requirement.new(">= 3.0")
+  s.required_ruby_version = ">= 3.0"
 
   s.metadata = {
     "changelog_uri" => "https://github.com/ruby-amqp/bunny/blob/main/ChangeLog.md",
     "source_code_uri" => "https://github.com/ruby-amqp/bunny/",
   }
 
-  # Sorted alphabetically.
   s.authors = [
     "Chris Duncan",
     "Eric Lindvall",
     "Jakub Stastny aka botanicus",
     "Michael S. Klishin",
-    "Stefan Kaes"]
+    "Stefan Kaes",
+  ]
 
   s.email = ["michael.s.klishin@gmail.com"]
 
-  # Dependencies
-  s.add_runtime_dependency 'amq-protocol', '~> 2.7'
-  s.add_runtime_dependency 'logger', '~> 1', '>= 1.7'
-  s.add_runtime_dependency 'sorted_set', '~> 1', '>= 1.0.2'
+  s.add_runtime_dependency "amq-protocol", "~> 2.7"
+  s.add_runtime_dependency "logger", "~> 1", ">= 1.7"
+  s.add_runtime_dependency "sorted_set", "~> 1", ">= 1.0.2"
 
-  # Files.
   s.extra_rdoc_files = ["README.md"]
-  s.files         = `git ls-files -- lib/*`.split("\n").reject { |f| f.match(%r{^bin/ci/}) }
+  s.files = Dir["lib/**/*", "README.md", "LICENSE", "ChangeLog.md"]
   s.require_paths = ["lib"]
 end

--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -519,7 +519,7 @@ module Bunny
     # @see http://rubybunny.info/articles/extensions.html RabbitMQ Extensions guide
     # @api public
     def queue(name = AMQ::Protocol::EMPTY_STRING, opts = {})
-      throw ArgumentError.new("queue name must not be nil") if name.nil?
+      raise ArgumentError, "queue name must not be nil" if name.nil?
 
       q = find_queue(name) || Bunny::Queue.new(self, name, opts)
 
@@ -539,8 +539,8 @@ module Bunny
     # @see #queue
     # @api public
     def quorum_queue(name, opts = {})
-      throw ArgumentError.new("quorum queue name must not be nil") if name.nil?
-      throw ArgumentError.new("quorum queue name must not be empty (server-named QQs do not make sense)") if name.empty?
+      raise ArgumentError, "quorum queue name must not be nil" if name.nil?
+      raise ArgumentError, "quorum queue name must not be empty (server-named QQs do not make sense)" if name.empty?
 
       durable_queue(name, Bunny::Queue::Types::QUORUM, opts)
     end
@@ -561,8 +561,8 @@ module Bunny
     # @see #queue
     # @api public
     def stream(name, opts = {})
-      throw ArgumentError.new("stream name must not be nil") if name.nil?
-      throw ArgumentError.new("stream name must not be empty (server-named QQs do not make sense)") if name.empty?
+      raise ArgumentError, "stream name must not be nil" if name.nil?
+      raise ArgumentError, "stream name must not be empty (server-named QQs do not make sense)" if name.empty?
 
       durable_queue(name, Bunny::Queue::Types::STREAM, opts)
     end
@@ -583,8 +583,8 @@ module Bunny
     # @see #queue
     # @api public
     def delayed_queue(name, opts = {})
-      throw ArgumentError.new("delayed queue name must not be nil") if name.nil?
-      throw ArgumentError.new("delayed queue name must not be empty") if name.empty?
+      raise ArgumentError, "delayed queue name must not be nil" if name.nil?
+      raise ArgumentError, "delayed queue name must not be empty" if name.empty?
 
       args = opts[:arguments] || {}
       args[Bunny::Queue::XArgs::DELAYED_RETRY_TYPE] = opts[:delayed_retry_type] if opts[:delayed_retry_type]
@@ -614,8 +614,8 @@ module Bunny
     # @see #queue
     # @api public
     def jms_queue(name, opts = {})
-      throw ArgumentError.new("JMS queue name must not be nil") if name.nil?
-      throw ArgumentError.new("JMS queue name must not be empty") if name.empty?
+      raise ArgumentError, "JMS queue name must not be nil" if name.nil?
+      raise ArgumentError, "JMS queue name must not be empty" if name.empty?
 
       args = opts[:arguments] || {}
       args[Bunny::Queue::XArgs::SELECTOR_FIELDS]          = opts[:selector_fields]          if opts[:selector_fields]
@@ -640,8 +640,8 @@ module Bunny
     # @see #queue
     # @api public
     def durable_queue(name, type = "classic", opts = {})
-      throw ArgumentError.new("queue name must not be nil") if name.nil?
-      throw ArgumentError.new("queue name must not be empty (server-named durable queues do not make sense)") if name.empty?
+      raise ArgumentError, "queue name must not be nil" if name.nil?
+      raise ArgumentError, "queue name must not be empty (server-named durable queues do not make sense)" if name.empty?
 
       final_opts = opts.merge({
         :type        => type,

--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # frozen_string_literal: true
 
-require "thread"
-require "monitor"
 require "set"
 
 require "bunny/concurrent/atomic_fixnum"

--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -771,11 +771,7 @@ module Bunny
       raise_if_no_longer_open!
       raise ArgumentError, "routing key cannot be longer than #{SHORTSTR_LIMIT} characters" if routing_key && routing_key.size > SHORTSTR_LIMIT
 
-      exchange_name = if exchange.respond_to?(:name)
-                        exchange.name
-                      else
-                        exchange
-                      end
+      exchange_name = exchange.is_a?(Bunny::Exchange) ? exchange.name : exchange
 
       mode = if opts.fetch(:persistent, true)
                2
@@ -846,11 +842,7 @@ module Bunny
       raise ArgumentError, "routing key cannot be longer than #{SHORTSTR_LIMIT} characters" if routing_key && routing_key.size > SHORTSTR_LIMIT
       return self if payloads.empty?
 
-      exchange_name = if exchange.respond_to?(:name)
-                        exchange.name
-                      else
-                        exchange
-                      end
+      exchange_name = exchange.is_a?(Bunny::Exchange) ? exchange.name : exchange
 
       mode = opts.fetch(:persistent, true) ? 2 : 1
       opts = opts.dup
@@ -1187,11 +1179,7 @@ module Bunny
       raise_if_no_longer_open!
       maybe_start_consumer_work_pool!
 
-      queue_name = if queue.respond_to?(:name)
-                     queue.name
-                   else
-                     queue
-                   end
+      queue_name = queue.is_a?(Bunny::Queue) ? queue.name : queue
 
       # helps avoid race condition between basic.consume-ok and basic.deliver if there are messages
       # in the queue already. MK.
@@ -1477,11 +1465,7 @@ module Bunny
     def queue_bind(name, exchange, opts = {})
       raise_if_no_longer_open!
 
-      exchange_name = if exchange.respond_to?(:name)
-                        exchange.name
-                      else
-                        exchange
-                      end
+      exchange_name = exchange.is_a?(Bunny::Exchange) ? exchange.name : exchange
       rk = (opts[:routing_key] || opts[:key])
       args = opts[:arguments]
 
@@ -1497,11 +1481,7 @@ module Bunny
     def queue_bind_without_recording_topology(name, exchange, opts = {})
       raise_if_no_longer_open!
 
-      exchange_name = if exchange.respond_to?(:name)
-                        exchange.name
-                      else
-                        exchange
-                      end
+      exchange_name = exchange.is_a?(Bunny::Exchange) ? exchange.name : exchange
 
       rk = (opts[:routing_key] || opts[:key])
       args = opts[:arguments]
@@ -1538,11 +1518,7 @@ module Bunny
     def queue_unbind(name, exchange, opts = {})
       raise_if_no_longer_open!
 
-      exchange_name = if exchange.respond_to?(:name)
-                        exchange.name
-                      else
-                        exchange
-                      end
+      exchange_name = exchange.is_a?(Bunny::Exchange) ? exchange.name : exchange
 
       rk = (opts[:routing_key] || opts[:key])
       args = opts[:arguments]
@@ -1691,16 +1667,8 @@ module Bunny
     def exchange_bind(source, destination, opts = {})
       result = self.exchange_bind_without_recording_topology(source, destination, opts)
 
-      source_name = if source.respond_to?(:name)
-                      source.name
-                    else
-                      source
-                    end
-      destination_name = if destination.respond_to?(:name)
-                           destination.name
-                         else
-                           destination
-                         end
+      source_name = source.is_a?(Bunny::Exchange) ? source.name : source
+      destination_name = destination.is_a?(Bunny::Exchange) ? destination.name : destination
       rk = (opts[:routing_key] || opts[:key])
       args = opts[:arguments]
       self.record_exchange_binding_with(self, source_name, destination_name, rk, args)
@@ -1714,17 +1682,9 @@ module Bunny
     def exchange_bind_without_recording_topology(source, destination, opts = {})
       raise_if_no_longer_open!
 
-      source_name = if source.respond_to?(:name)
-                      source.name
-                    else
-                      source
-                    end
+      source_name = source.is_a?(Bunny::Exchange) ? source.name : source
 
-      destination_name = if destination.respond_to?(:name)
-                           destination.name
-                         else
-                           destination
-                         end
+      destination_name = destination.is_a?(Bunny::Exchange) ? destination.name : destination
 
       rk = (opts[:routing_key] || opts[:key])
       args = opts[:arguments]
@@ -1762,17 +1722,9 @@ module Bunny
     def exchange_unbind(source, destination, opts = {})
       raise_if_no_longer_open!
 
-      source_name = if source.respond_to?(:name)
-                      source.name
-                    else
-                      source
-                    end
+      source_name = source.is_a?(Bunny::Exchange) ? source.name : source
 
-      destination_name = if destination.respond_to?(:name)
-                           destination.name
-                         else
-                           destination
-                         end
+      destination_name = destination.is_a?(Bunny::Exchange) ? destination.name : destination
 
       rk = (opts[:routing_key] || opts[:key])
       args = opts[:arguments]

--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -110,8 +110,8 @@ module Bunny
   #     ch2 = conn.create_channel
   #     q   = "bunny.examples.recovery.q#{rand}"
   #
-  #     ch2.queue_declare(q, :durable => false)
-  #     ch2.queue_declare(q, :durable => true)
+  #     ch2.queue_declare(q, durable: false)
+  #     ch2.queue_declare(q, durable: true)
   #   rescue Bunny::PreconditionFailed => e
   #     puts "Channel-level exception! Code: #{e.channel_close.reply_code}, message: #{e.channel_close.reply_text}"
   #   ensure
@@ -591,7 +591,7 @@ module Bunny
       args[Bunny::Queue::XArgs::DELAYED_RETRY_MIN]  = opts[:delayed_retry_min]  if opts[:delayed_retry_min]
       args[Bunny::Queue::XArgs::DELAYED_RETRY_MAX]  = opts[:delayed_retry_max]  if opts[:delayed_retry_max]
 
-      final_opts = opts.merge(:arguments => args)
+      final_opts = opts.merge(arguments: args)
       final_opts.delete(:delayed_retry_type)
       final_opts.delete(:delayed_retry_min)
       final_opts.delete(:delayed_retry_max)
@@ -621,7 +621,7 @@ module Bunny
       args[Bunny::Queue::XArgs::SELECTOR_FIELDS]          = opts[:selector_fields]          if opts[:selector_fields]
       args[Bunny::Queue::XArgs::SELECTOR_FIELD_MAX_BYTES] = opts[:selector_field_max_bytes] if opts[:selector_field_max_bytes]
 
-      final_opts = opts.merge(:arguments => args)
+      final_opts = opts.merge(arguments: args)
       final_opts.delete(:selector_fields)
       final_opts.delete(:selector_field_max_bytes)
 
@@ -643,13 +643,13 @@ module Bunny
       raise ArgumentError, "queue name must not be nil" if name.nil?
       raise ArgumentError, "queue name must not be empty (server-named durable queues do not make sense)" if name.empty?
 
-      final_opts = opts.merge({
-        :type        => type,
-        :durable     => true,
+      final_opts = opts.merge(
+        type:        type,
+        durable:     true,
         # exclusive or auto-delete QQs do not make much sense
-        :exclusive   => false,
-        :auto_delete => false
-      })
+        exclusive:   false,
+        auto_delete: false
+      )
       q = find_queue(name) || Bunny::Queue.new(self, name, final_opts)
 
       record_queue(q)
@@ -664,7 +664,7 @@ module Bunny
     # @api public
     def temporary_queue(opts = {})
       temporary_queue_opts = {
-        :exclusive => true
+        exclusive: true
       }
       queue("", opts.merge(temporary_queue_opts))
     end
@@ -912,12 +912,12 @@ module Bunny
     #   conn.start
     #   ch   = conn.create_channel
     #   # here we assume the queue already exists and has messages
-    #   delivery_info, properties, payload = ch.basic_get("bunny.examples.queue1", :manual_ack => true)
+    #   delivery_info, properties, payload = ch.basic_get("bunny.examples.queue1", manual_ack: true)
     #   ch.acknowledge(delivery_info.delivery_tag)
     # @see Bunny::Queue#pop
     # @see http://rubybunny.info/articles/queues.html Queues and Consumers guide
     # @api public
-    def basic_get(queue, opts = {:manual_ack => true})
+    def basic_get(queue, opts = { manual_ack: true })
       raise_if_no_longer_open!
 
       unless opts[:ack].nil?
@@ -1036,7 +1036,7 @@ module Bunny
     #
     #   ch    = conn.create_channel
     #   # we assume the queue exists and has messages
-    #   delivery_info, properties, payload = ch.basic_get("bunny.examples.queue3", :manual_ack => true)
+    #   delivery_info, properties, payload = ch.basic_get("bunny.examples.queue3", manual_ack: true)
     #   ch.basic_reject(delivery_info.delivery_tag, true)
     #
     # @see Bunny::Channel#basic_nack
@@ -1071,7 +1071,7 @@ module Bunny
     #
     #   ch    = conn.create_channel
     #   # we assume the queue exists and has messages
-    #   delivery_info, properties, payload = ch.basic_get("bunny.examples.queue3", :manual_ack => true)
+    #   delivery_info, properties, payload = ch.basic_get("bunny.examples.queue3", manual_ack: true)
     #   ch.basic_ack(delivery_info.delivery_tag.to_i)
     #
     # @example Ack multiple messages fetched via basic.get
@@ -1080,9 +1080,9 @@ module Bunny
     #
     #   ch    = conn.create_channel
     #   # we assume the queue exists and has messages
-    #   _, _, payload1 = ch.basic_get("bunny.examples.queue3", :manual_ack => true)
-    #   _, _, payload2 = ch.basic_get("bunny.examples.queue3", :manual_ack => true)
-    #   delivery_info, properties, payload3 = ch.basic_get("bunny.examples.queue3", :manual_ack => true)
+    #   _, _, payload1 = ch.basic_get("bunny.examples.queue3", manual_ack: true)
+    #   _, _, payload2 = ch.basic_get("bunny.examples.queue3", manual_ack: true)
+    #   delivery_info, properties, payload3 = ch.basic_get("bunny.examples.queue3", manual_ack: true)
     #   # ack all fetched messages up to payload3
     #   ch.basic_ack(delivery_info.delivery_tag.to_i, true)
     #
@@ -1131,7 +1131,7 @@ module Bunny
     #
     #   ch    = conn.create_channel
     #   # we assume the queue exists and has messages
-    #   delivery_info, properties, payload = ch.basic_get("bunny.examples.queue3", :manual_ack => true)
+    #   delivery_info, properties, payload = ch.basic_get("bunny.examples.queue3", manual_ack: true)
     #   ch.basic_nack(delivery_info.delivery_tag, false, true)
     #
     #
@@ -1141,9 +1141,9 @@ module Bunny
     #
     #   ch    = conn.create_channel
     #   # we assume the queue exists and has messages
-    #   _, _, payload1 = ch.basic_get("bunny.examples.queue3", :manual_ack => true)
-    #   _, _, payload2 = ch.basic_get("bunny.examples.queue3", :manual_ack => true)
-    #   delivery_info, properties, payload3 = ch.basic_get("bunny.examples.queue3", :manual_ack => true)
+    #   _, _, payload1 = ch.basic_get("bunny.examples.queue3", manual_ack: true)
+    #   _, _, payload2 = ch.basic_get("bunny.examples.queue3", manual_ack: true)
+    #   delivery_info, properties, payload3 = ch.basic_get("bunny.examples.queue3", manual_ack: true)
     #   # requeue all fetched messages up to payload3
     #   ch.basic_nack(delivery_info.delivery_tag, true, true)
     #

--- a/lib/bunny/channel_id_allocator.rb
+++ b/lib/bunny/channel_id_allocator.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "thread"
-require "monitor"
 require "amq/int_allocator"
 
 module Bunny

--- a/lib/bunny/concurrent/atomic_fixnum.rb
+++ b/lib/bunny/concurrent/atomic_fixnum.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "set"
-require "thread"
-require "monitor"
 
 module Bunny
   module Concurrent

--- a/lib/bunny/concurrent/condition.rb
+++ b/lib/bunny/concurrent/condition.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "thread"
-require "monitor"
-
 module Bunny
   # @private
   module Concurrent

--- a/lib/bunny/concurrent/continuation_queue.rb
+++ b/lib/bunny/concurrent/continuation_queue.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "thread"
-
 module Bunny
   module Concurrent
     # Continuation queue implementation for MRI and Rubinius

--- a/lib/bunny/concurrent/exception_accumulator.rb
+++ b/lib/bunny/concurrent/exception_accumulator.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "thread"
-
 module Bunny
   module Concurrent
     # A thread-safe exception accumulator that stores exceptions for later retrieval

--- a/lib/bunny/concurrent/synchronized_sorted_set.rb
+++ b/lib/bunny/concurrent/synchronized_sorted_set.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "set"
-require "thread"
 
 module Bunny
   module Concurrent

--- a/lib/bunny/consumer.rb
+++ b/lib/bunny/consumer.rb
@@ -111,7 +111,7 @@ module Bunny
     # @return [String] Name of the queue this consumer is on
     # @api public
     def queue_name
-      if @queue.respond_to?(:name)
+      if @queue.is_a?(Bunny::Queue)
         @queue.name
       else
         @queue

--- a/lib/bunny/consumer_work_pool.rb
+++ b/lib/bunny/consumer_work_pool.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "thread"
-
 module Bunny
   # Thread pool that dispatches consumer deliveries. Not supposed to be shared between channels
   # or threads.

--- a/lib/bunny/cruby/socket.rb
+++ b/lib/bunny/cruby/socket.rb
@@ -28,7 +28,7 @@ module Bunny
         @__bunny_socket_eof_flag__ = false
       end
       socket.extend self
-      socket.options = { :host => host, :port => port }.merge(options)
+      socket.options = { host: host, port: port }.merge(options)
       socket
     rescue Errno::ETIMEDOUT
       raise ClientTimeout

--- a/lib/bunny/cruby/socket.rb
+++ b/lib/bunny/cruby/socket.rb
@@ -11,21 +11,10 @@ module Bunny
   module Socket
     attr_accessor :options
 
-    READ_RETRY_EXCEPTION_CLASSES = if defined?(IO::EAGAINWaitReadable)
-                                     # Ruby 2.1+
-                                     [Errno::EAGAIN, Errno::EWOULDBLOCK, IO::WaitReadable,
-                                      IO::EAGAINWaitReadable, IO::EWOULDBLOCKWaitReadable]
-                                   else
-                                     # 2.0
-                                     [Errno::EAGAIN, Errno::EWOULDBLOCK, IO::WaitReadable]
-                                   end
-    WRITE_RETRY_EXCEPTION_CLASSES = if defined?(IO::EAGAINWaitWritable)
-                                      [Errno::EAGAIN, Errno::EWOULDBLOCK, IO::WaitWritable,
-                                       IO::EAGAINWaitWritable, IO::EWOULDBLOCKWaitWritable]
-                                    else
-                                      # 2.0
-                                      [Errno::EAGAIN, Errno::EWOULDBLOCK, IO::WaitWritable]
-                                    end
+    READ_RETRY_EXCEPTION_CLASSES = [Errno::EAGAIN, Errno::EWOULDBLOCK, IO::WaitReadable,
+                                    IO::EAGAINWaitReadable, IO::EWOULDBLOCKWaitReadable].freeze
+    WRITE_RETRY_EXCEPTION_CLASSES = [Errno::EAGAIN, Errno::EWOULDBLOCK, IO::WaitWritable,
+                                     IO::EAGAINWaitWritable, IO::EWOULDBLOCKWaitWritable].freeze
 
     def self.open(host, port, options = {})
       socket = ::Socket.tcp(host, port, nil, nil,

--- a/lib/bunny/cruby/ssl_socket.rb
+++ b/lib/bunny/cruby/ssl_socket.rb
@@ -10,21 +10,10 @@ module Bunny
     # methods found in Bunny::Socket.
     class SSLSocket < OpenSSL::SSL::SSLSocket
 
-    READ_RETRY_EXCEPTION_CLASSES = if defined?(IO::EAGAINWaitReadable)
-                                     # Ruby 2.1+
-                                     [Errno::EAGAIN, Errno::EWOULDBLOCK, IO::WaitReadable,
-                                      IO::EAGAINWaitReadable, IO::EWOULDBLOCKWaitReadable]
-                                   else
-                                     # 2.0
-                                     [Errno::EAGAIN, Errno::EWOULDBLOCK, IO::WaitReadable]
-                                   end
-    WRITE_RETRY_EXCEPTION_CLASSES = if defined?(IO::EAGAINWaitWritable)
-                                      [Errno::EAGAIN, Errno::EWOULDBLOCK, IO::WaitWritable,
-                                       IO::EAGAINWaitWritable, IO::EWOULDBLOCKWaitWritable]
-                                    else
-                                      # 2.0
-                                      [Errno::EAGAIN, Errno::EWOULDBLOCK, IO::WaitWritable]
-                                    end
+    READ_RETRY_EXCEPTION_CLASSES = [Errno::EAGAIN, Errno::EWOULDBLOCK, IO::WaitReadable,
+                                    IO::EAGAINWaitReadable, IO::EWOULDBLOCKWaitReadable].freeze
+    WRITE_RETRY_EXCEPTION_CLASSES = [Errno::EAGAIN, Errno::EWOULDBLOCK, IO::WaitWritable,
+                                     IO::EAGAINWaitWritable, IO::EWOULDBLOCKWaitWritable].freeze
 
       def initialize(*args)
         super

--- a/lib/bunny/delivery_info.rb
+++ b/lib/bunny/delivery_info.rb
@@ -52,13 +52,13 @@ module Bunny
     # @return [Hash] Hash representation of this delivery info
     def to_hash
       @hash ||= {
-        :consumer_tag => @basic_deliver.consumer_tag,
-        :delivery_tag => @basic_deliver.delivery_tag,
-        :redelivered  => @basic_deliver.redelivered,
-        :exchange     => @basic_deliver.exchange,
-        :routing_key  => @basic_deliver.routing_key,
-        :consumer     => @consumer,
-        :channel      => @channel
+        consumer_tag: @basic_deliver.consumer_tag,
+        delivery_tag: @basic_deliver.delivery_tag,
+        redelivered:  @basic_deliver.redelivered,
+        exchange:     @basic_deliver.exchange,
+        routing_key:  @basic_deliver.routing_key,
+        consumer:     @consumer,
+        channel:      @channel
       }
     end
 

--- a/lib/bunny/exchange.rb
+++ b/lib/bunny/exchange.rb
@@ -63,7 +63,7 @@ module Bunny
     # @example Publishing a messages to the tasks queue
     #   channel     = Bunny::Channel.new(connection)
     #   tasks_queue = channel.queue("tasks")
-    #   Bunny::Exchange.default(channel).publish("make clean", :routing_key => "tasks")
+    #   Bunny::Exchange.default(channel).publish("make clean", routing_key: "tasks")
     #
     # @see http://rubybunny.info/articles/exchanges.html Exchanges and Publishing guide
     # @see http://www.rabbitmq.com/resources/specs/amqp0-9-1.pdf AMQP 0.9.1 specification (Section 2.1.2.4)
@@ -72,7 +72,7 @@ module Bunny
     # @return [Exchange] An instance that corresponds to the default exchange (of type direct).
     # @api public
     def self.default(channel_or_connection)
-      self.new(channel_or_connection, :direct, AMQ::Protocol::EMPTY_STRING, :no_declare => true)
+      self.new(channel_or_connection, :direct, AMQ::Protocol::EMPTY_STRING, no_declare: true)
     end
 
     # @param [Bunny::Channel] channel Channel this exchange will use.
@@ -271,15 +271,15 @@ module Bunny
     # @private
     def self.add_default_options(name, opts)
       # :nowait is always false for Bunny
-      h = { :queue => name, :nowait => false }.merge(opts)
+      h = { queue: name, nowait: false }.merge(opts)
 
       if name.empty?
         {
-          :passive     => false,
-          :durable     => false,
-          :auto_delete => false,
-          :internal    => false,
-          :arguments   => nil
+          passive:     false,
+          durable:     false,
+          auto_delete: false,
+          internal:    false,
+          arguments:   nil
         }.merge(h)
       else
         h

--- a/lib/bunny/framing.rb
+++ b/lib/bunny/framing.rb
@@ -3,7 +3,6 @@
 module Bunny
   # @private
   module Framing
-    ENCODINGS_SUPPORTED = defined? Encoding
     HEADER_SLICE = (0..6).freeze
     DATA_SLICE = (7..-1).freeze
     PAYLOAD_SLICE = (0..-2).freeze
@@ -18,7 +17,7 @@ module Bunny
           payload             = data[PAYLOAD_SLICE]
           frame_end           = data[-1, 1]
 
-          frame_end.force_encoding(AMQ::Protocol::Frame::FINAL_OCTET.encoding) if ENCODINGS_SUPPORTED
+          frame_end.force_encoding(AMQ::Protocol::Frame::FINAL_OCTET.encoding)
 
           # 1) the size is miscalculated
           if payload.bytesize != size

--- a/lib/bunny/get_response.rb
+++ b/lib/bunny/get_response.rb
@@ -47,11 +47,11 @@ module Bunny
     # @return [Hash] Hash representation of this delivery info
     def to_hash
       @hash ||= {
-        :delivery_tag => @get_ok.delivery_tag,
-        :redelivered  => @get_ok.redelivered,
-        :exchange     => @get_ok.exchange,
-        :routing_key  => @get_ok.routing_key,
-        :channel      => @channel
+        delivery_tag: @get_ok.delivery_tag,
+        redelivered:  @get_ok.redelivered,
+        exchange:     @get_ok.exchange,
+        routing_key:  @get_ok.routing_key,
+        channel:      @channel
       }
     end
 

--- a/lib/bunny/heartbeat_sender.rb
+++ b/lib/bunny/heartbeat_sender.rb
@@ -30,7 +30,7 @@ module Bunny
         @interval = [(period / 2) - 1, 0.4].max
 
         @thread = Thread.new(&method(:run))
-        @thread.report_on_exception = false if @thread.respond_to?(:report_on_exception)
+        @thread.report_on_exception = false
       end
     end
 

--- a/lib/bunny/heartbeat_sender.rb
+++ b/lib/bunny/heartbeat_sender.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "thread"
 require "amq/protocol/client"
 require "amq/protocol/frame"
 

--- a/lib/bunny/queue.rb
+++ b/lib/bunny/queue.rb
@@ -378,8 +378,8 @@ module Bunny
       # be extra defensive
       args = args0 || {}
       q_type = args["x-queue-type"] || args[:"x-queue-type"]
-      throw ArgumentError.new(
-        "unsupported queue type #{q_type.inspect}, supported ones: #{Types::KNOWN.join(', ')}") if (q_type and !Types.known?(q_type))
+      raise ArgumentError,
+        "unsupported queue type #{q_type.inspect}, supported ones: #{Types::KNOWN.join(', ')}" if (q_type and !Types.known?(q_type))
     end
 
     #

--- a/lib/bunny/queue.rb
+++ b/lib/bunny/queue.rb
@@ -168,7 +168,7 @@ module Bunny
 
       # store bindings for automatic recovery. We need to be very careful to
       # not cause an infinite rebinding loop here when we recover. MK.
-      binding = { :exchange => exchange_name, :routing_key => (opts[:routing_key] || opts[:key]), :arguments => opts[:arguments] }
+      binding = { exchange: exchange_name, routing_key: (opts[:routing_key] || opts[:key]), arguments: opts[:arguments] }
       @bindings.push(binding) unless @bindings.include?(binding)
 
       self
@@ -214,11 +214,11 @@ module Bunny
     # @see http://rubybunny.info/articles/queues.html Queues and Consumers guide
     # @api public
     def subscribe(opts = {
-                    :consumer_tag    => @channel.generate_consumer_tag,
-                    :manual_ack      => false,
-                    :exclusive       => false,
-                    :block           => false,
-                    :on_cancellation => nil
+                    consumer_tag:    @channel.generate_consumer_tag,
+                    manual_ack:      false,
+                    exclusive:       false,
+                    block:           false,
+                    on_cancellation: nil
                   }, &block)
 
       unless opts[:ack].nil?
@@ -256,7 +256,7 @@ module Bunny
     #
     # @see http://rubybunny.info/articles/queues.html Queues and Consumers guide
     # @api public
-    def subscribe_with(consumer, opts = {:block => false})
+    def subscribe_with(consumer, opts = { block: false })
       @channel.basic_consume_with(consumer)
 
       @channel.work_pool.join if opts[:block]
@@ -281,13 +281,13 @@ module Bunny
     #   ch   = conn.create_channel
     #   q = ch.queue("test1")
     #   x = ch.default_exchange
-    #   x.publish("Hello, everybody!", :routing_key => 'test1')
+    #   x.publish("Hello, everybody!", routing_key: 'test1')
     #
     #   delivery_info, properties, payload = q.pop
     #
     #   puts "This is the message: " + payload + "\n\n"
     #   conn.close
-    def pop(opts = {:manual_ack => false}, &block)
+    def pop(opts = { manual_ack: false }, &block)
       unless opts[:ack].nil?
         warn "[DEPRECATION] `:ack` is deprecated.  Please use `:manual_ack` instead."
         opts[:manual_ack] = opts[:ack]
@@ -323,7 +323,7 @@ module Bunny
     # @see Bunny::Channel#default_exchange
     # @see http://rubybunny.info/articles/exchanges.html Exchanges and Publishing guide
     def publish(payload, opts = {})
-      @channel.default_exchange.publish(payload, opts.merge(:routing_key => @name))
+      @channel.default_exchange.publish(payload, opts.merge(routing_key: @name))
 
       self
     end
@@ -357,9 +357,9 @@ module Bunny
     # @see #message_count
     # @see #consumer_count
     def status
-      queue_declare_ok = @channel.queue_declare(@name, @options.merge(:passive => true))
-      {:message_count => queue_declare_ok.message_count,
-        :consumer_count => queue_declare_ok.consumer_count}
+      queue_declare_ok = @channel.queue_declare(@name, @options.merge(passive: true))
+      { message_count: queue_declare_ok.message_count,
+        consumer_count: queue_declare_ok.consumer_count }
     end
 
     # @return [Integer] How many messages the queue has ready (e.g. not delivered but not unacknowledged)
@@ -397,15 +397,15 @@ module Bunny
     # @private
     def self.add_default_options(name, opts)
       # :nowait is always false for Bunny
-      h = { :queue => name, :nowait => false }.merge(opts)
+      h = { queue: name, nowait: false }.merge(opts)
 
       if name.empty?
         {
-          :passive     => false,
-          :durable     => false,
-          :exclusive   => false,
-          :auto_delete => false,
-          :arguments   => nil
+          passive:     false,
+          durable:     false,
+          exclusive:   false,
+          auto_delete: false,
+          arguments:   nil
         }.merge(h)
       else
         h

--- a/lib/bunny/queue.rb
+++ b/lib/bunny/queue.rb
@@ -159,7 +159,7 @@ module Bunny
     def bind(exchange, opts = {})
       @channel.queue_bind(@name, exchange, opts)
 
-      exchange_name = if exchange.respond_to?(:name)
+      exchange_name = if exchange.is_a?(Bunny::Exchange)
                         exchange.name
                       else
                         exchange
@@ -188,7 +188,7 @@ module Bunny
     def unbind(exchange, opts = {})
       @channel.queue_unbind(@name, exchange, opts)
 
-      exchange_name = if exchange.respond_to?(:name)
+      exchange_name = if exchange.is_a?(Bunny::Exchange)
                         exchange.name
                       else
                         exchange

--- a/lib/bunny/reader_loop.rb
+++ b/lib/bunny/reader_loop.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "thread"
-
 module Bunny
   # Network activity loop that reads and passes incoming AMQP 0.9.1 methods for
   # processing. They are dispatched further down the line in Bunny::Session and Bunny::Channel.

--- a/lib/bunny/return_info.rb
+++ b/lib/bunny/return_info.rb
@@ -41,10 +41,10 @@ module Bunny
     # @return [Hash] Hash representation of this returned delivery info
     def to_hash
       @hash ||= {
-        :reply_code   => @basic_return.reply_code,
-        :reply_text   => @basic_return.reply_text,
-        :exchange     => @basic_return.exchange,
-        :routing_key  => @basic_return.routing_key
+        reply_code:   @basic_return.reply_code,
+        reply_text:   @basic_return.reply_text,
+        exchange:     @basic_return.exchange,
+        routing_key:  @basic_return.routing_key
       }
     end
 

--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -49,19 +49,19 @@ module Bunny
 
     # RabbitMQ client metadata
     DEFAULT_CLIENT_PROPERTIES = {
-      :capabilities => {
-        :publisher_confirms           => true,
-        :consumer_cancel_notify       => true,
-        :exchange_exchange_bindings   => true,
+      capabilities: {
+        publisher_confirms:           true,
+        consumer_cancel_notify:       true,
+        exchange_exchange_bindings:   true,
         :"basic.nack"                 => true,
         :"connection.blocked"         => true,
         # See http://www.rabbitmq.com/auth-notification.html
-        :authentication_failure_close => true
+        authentication_failure_close: true
       },
-      :product      => "Bunny",
-      :platform     => ::RUBY_DESCRIPTION,
-      :version      => Bunny::VERSION,
-      :information  => "https://github.com/ruby-amqp/bunny",
+      product:     "Bunny",
+      platform:    ::RUBY_DESCRIPTION,
+      version:     Bunny::VERSION,
+      information: "https://github.com/ruby-amqp/bunny",
     }
 
     # @private
@@ -575,7 +575,7 @@ module Bunny
     def queue_exists?(name)
       ch = create_channel
       begin
-        ch.queue(name, :passive => true)
+        ch.queue(name, passive: true)
         true
       rescue Bunny::ResourceLocked => _
         true
@@ -597,7 +597,7 @@ module Bunny
     def exchange_exists?(name)
       ch = create_channel
       begin
-        ch.exchange(name, :passive => true)
+        ch.exchange(name, passive: true)
         true
       rescue Bunny::NotFound => _
         false
@@ -1709,7 +1709,7 @@ module Bunny
           @transport = Transport.new(self,
                                      host_from_address(address),
                                      port_from_address(address),
-                                     @opts.merge(:session_error_handler => @session_error_handler)
+                                     @opts.merge(session_error_handler: @session_error_handler)
           )
 
           # Reset the cached progname for the logger only when no logger was provided

--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "socket"
-require "thread"
-require "monitor"
 
 require "bunny/transport"
 require "bunny/channel_id_allocator"

--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -784,16 +784,13 @@ module Bunny
     # @private
     def handle_frameset(ch_number, frames)
       method = frames.first
+      ch = @channels[ch_number]
 
       case method
-      when AMQ::Protocol::Basic::GetOk then
-        @channels[ch_number].handle_basic_get_ok(*frames)
-      when AMQ::Protocol::Basic::GetEmpty then
-        @channels[ch_number].handle_basic_get_empty(*frames)
-      when AMQ::Protocol::Basic::Return then
-        @channels[ch_number].handle_basic_return(*frames)
-      else
-        @channels[ch_number].handle_frameset(*frames)
+      when AMQ::Protocol::Basic::GetOk    then ch.handle_basic_get_ok(*frames)
+      when AMQ::Protocol::Basic::GetEmpty then ch.handle_basic_get_empty(*frames)
+      when AMQ::Protocol::Basic::Return   then ch.handle_basic_return(*frames)
+      else                                     ch.handle_frameset(*frames)
       end
     end
 

--- a/lib/bunny/transport.rb
+++ b/lib/bunny/transport.rb
@@ -303,7 +303,7 @@ module Bunny
     def self.reachable?(host, port, timeout)
       begin
         s = Bunny::SocketImpl.open(host, port,
-          :connect_timeout => timeout)
+          connect_timeout: timeout)
 
         true
       rescue SocketError, Timeout::Error => _e
@@ -325,8 +325,8 @@ module Bunny
       @logger.debug("Using connection timeout of #{@connect_timeout} when connecting to #{@host}:#{@port}")
       begin
         @socket = Bunny::SocketImpl.open(@host, @port,
-          :keepalive      => @opts[:keepalive],
-          :connect_timeout => @connect_timeout)
+          keepalive:       @opts[:keepalive],
+          connect_timeout: @connect_timeout)
       rescue StandardError, ClientTimeout => e
         @status = :not_connected
         raise Bunny::TCPConnectionFailed.new(e, self.hostname, self.port)

--- a/lib/bunny/transport.rb
+++ b/lib/bunny/transport.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "socket"
-require "thread"
-require "monitor"
 
 begin
   require "openssl"

--- a/lib/bunny/version.rb
+++ b/lib/bunny/version.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module Bunny

--- a/spec/higher_level_api/integration/queue_declare_spec.rb
+++ b/spec/higher_level_api/integration/queue_declare_spec.rb
@@ -280,7 +280,7 @@ describe Bunny::Queue do
     context "when #{helper} is used with nil name" do
       it "raises an error" do
         ch = connection.create_channel
-        expect { ch.send(helper, nil) }.to raise_error(UncaughtThrowError)
+        expect { ch.send(helper, nil) }.to raise_error(ArgumentError)
         ch.close
       end
     end
@@ -288,7 +288,7 @@ describe Bunny::Queue do
     context "when #{helper} is used with empty name" do
       it "raises an error" do
         ch = connection.create_channel
-        expect { ch.send(helper, "") }.to raise_error(UncaughtThrowError)
+        expect { ch.send(helper, "") }.to raise_error(ArgumentError)
         ch.close
       end
     end


### PR DESCRIPTION
## Motivation

These messaging gems are critical dependencies in our production app, so I've been investing time in modernising the RabbitMQ Ruby ecosystem (hutch, amq-protocol) and want to contribute similar cleanup to Bunny. This PR removes accumulated legacy code and tightens things up for the Ruby 3.0+ baseline Bunny already requires.

## Changes

**Ruby 3.0 modernisation**
- Remove Ruby 2.0/2.1 compatibility guards (`defined? Encoding`, `respond_to?(:report_on_exception)`, encoding magic comments, `require "thread"`, `require "monitor"`)
- Sweep the remaining `:key =>` hash rocket syntax in `lib/` over to `key:`

**Bug fix**
- Several queue helpers (`quorum_queue`, `stream`, `durable_queue`, `delayed_queue`, `jms_queue`, `queue`) used `throw ArgumentError.new(...)` to signal validation errors. With no matching `catch`, this raises `UncaughtThrowError` instead of `ArgumentError`. Switched to `raise ArgumentError, "..."` and updated the specs that asserted the wrong error class

**Code quality**
- Deduplicate `@channels[ch_number]` hash lookup in `handle_frameset` — single lookup per frame instead of two
- Replace `respond_to?(:name)` duck-type checks with `is_a?(Bunny::Exchange)` / `is_a?(Bunny::Queue)` in the publish, bind, and consumer hot paths

**Gem / Gemfile cleanup**
- Remove redundant shebang and encoding comments from gemspec and Gemfile
- Remove duplicate vendor block from Gemfile
- Pin `amq-protocol` to `~> 2.7` to match the runtime dependency