### PR TITLE
fix: [737] preserve Consumer identity on network recovery

### DIFF
--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -1190,8 +1190,12 @@ module Bunny
     # @private
     def recover_consumer(c)
       c.channel.maybe_reinitialize_consumer_pool!
-      c.channel.basic_consume(c.queue_name, c.consumer_tag, !c.manual_ack, c.exclusive, c.arguments) do |*args|
-        c.callable.call(*args)
+      if c.callable.is_a?(Bunny::Consumer)
+        c.channel.basic_consume_with(c.callable)
+      else
+        c.channel.basic_consume(c.queue_name, c.consumer_tag, !c.manual_ack, c.exclusive, c.arguments) do |*args|
+          c.callable.call(*args)
+        end
       end
     end
 

--- a/spec/higher_level_api/integration/connection_recovery_spec.rb
+++ b/spec/higher_level_api/integration/connection_recovery_spec.rb
@@ -275,6 +275,61 @@ describe "Connection recovery" do
     end
   end
 
+  it "preserves Consumer instance identity and cancellation callbacks across recovery" do
+    with_open do |c|
+      cancelled = false
+
+      ch = c.create_channel
+      q  = ch.queue("", exclusive: true)
+      consumer = Bunny::Consumer.new(ch, q)
+      consumer.on_cancellation { cancelled = true }
+      q.subscribe_with(consumer)
+
+      original_tag = consumer.consumer_tag
+      close_all_connections!
+      wait_for_recovery_with { connections.any? && ch.open? }
+
+      expect(ch.consumers[original_tag]).to equal(consumer)
+
+      q.delete
+      poll_until { cancelled }
+    end
+  end
+
+  it "recovers block-form Queue#subscribe consumers and delivers messages after recovery" do
+    with_open do |c|
+      delivered = false
+
+      ch = c.create_channel
+      ch.confirm_select
+      q  = ch.queue("", exclusive: true)
+      q.subscribe { |_, _, _| delivered = true }
+
+      close_all_connections!
+      wait_for_recovery_with { connections.any? && ch.open? }
+
+      q.publish("")
+      ch.wait_for_confirms
+      poll_until { delivered }
+    end
+  end
+
+  it "does not duplicate or corrupt the topology registry entry after recovery via basic_consume_with" do
+    with_open do |c|
+      ch = c.create_channel
+      q  = ch.queue("", exclusive: true)
+      consumer = Bunny::Consumer.new(ch, q)
+      q.subscribe_with(consumer)
+
+      original_tag = consumer.consumer_tag
+      close_all_connections!
+      wait_for_recovery_with { connections.any? && ch.open? }
+
+      expect(c.topology_registry.consumers.size).to eq 1
+      expect(c.topology_registry.consumers[original_tag].callable).to equal(consumer)
+    end
+  end
+
   it "recovers all consumers" do
     n = 32
 

--- a/spec/unit/session_recover_consumer_spec.rb
+++ b/spec/unit/session_recover_consumer_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe Bunny::Session do
+  describe "#recover_consumer" do
+    let(:channel) { instance_double(Bunny::Channel) }
+
+    before { allow(channel).to receive(:maybe_reinitialize_consumer_pool!) }
+
+    def recorded_consumer_with(callable)
+      Bunny::RecordedConsumer.new(channel, "bunny.test.queue")
+        .with_consumer_tag("bunny-test-tag")
+        .with_callable(callable)
+        .with_manual_ack(false)
+        .with_exclusive(false)
+        .with_arguments({})
+    end
+
+    it "calls basic_consume_with to preserve Consumer instance identity" do
+      consumer = Bunny::Consumer.new(channel, "bunny.test.queue", "bunny-test-tag")
+      expect(channel).to receive(:basic_consume_with).with(consumer)
+      Bunny.new.recover_consumer(recorded_consumer_with(consumer))
+    end
+
+    it "calls basic_consume with a block when callable is a Proc" do
+      callable = proc { |*args| args }
+      expect(channel).to receive(:basic_consume).with("bunny.test.queue", "bunny-test-tag", true, false, {})
+      Bunny.new.recover_consumer(recorded_consumer_with(callable))
+    end
+  end
+end


### PR DESCRIPTION
When recovering a consumer whose callable is a Bunny::Consumer instance, use basic_consume_with instead of basic_consume so that the original object reference—and any on_cancellation callbacks registered on it—are preserved after reconnection.