### PR TITLE
Connection recovery: survive connection.close during negotiation and repeated failures mid-recovery

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,40 @@ GitHub issue: [#735](https://github.com/ruby-amqp/bunny/pull/735)
 
 ### Bug Fixes
 
+#### Connection Recovery Survives connection.close During Negotiation and Repeated Failures Mid-Recovery
+
+Connection recovery could previously terminate silently - leaving the client
+permanently disconnected with no further retries or log lines - when the
+connection was lost again while a recovery was already in progress, e.g. when
+a node that is being drained (put into maintenance mode) closes client
+connections repeatedly, including during connection negotiation
+(`connection.close` in response to `connection.open`).
+
+Several changes address this scenario:
+
+ * The recovery guard flag is now updated atomically and stays in effect until
+   channel and topology recovery complete, so concurrent failure signals
+   (from the reader loop and from publishing threads) can no longer start
+   overlapping recoveries that used to sabotage each other
+ * If the connection is lost again while channels or topology are being
+   recovered, another full recovery round is performed instead of silently
+   dropping the failure
+ * A `connection.close` received during negotiation with automatic recovery
+   enabled is now raised in the recovery thread and handled by the recovery
+   retry logic, instead of being delivered to the session error handler while
+   the recovery round terminates without retrying
+ * The connection status is set to `:open` and the heartbeat sender is started
+   only after `connection.open-ok` is actually received
+ * Connection negotiation now always uses a finite socket read timeout, even
+   when read timeouts are disabled for the connection's lifetime: a peer that
+   accepts a TCP connection but never responds at the protocol level - such as
+   a suspended listener of a node in maintenance mode — could previously block
+   the handshake, and therefore the recovery loop, indefinitely
+ * A failure to re-register an individual entity during topology recovery no
+   longer aborts recovery of the remaining ones: the per-entity rescue clauses
+   now use an explicit `::StandardError` (a bare `Exception` resolves to
+   `Bunny::Exception` inside this library and did not catch `Timeout::Error`)
+
 #### `Bunny::Consumer` Identity Preserved on Recovery
 
 Consumers registered via `Queue#subscribe_with` or `Channel#basic_consume_with`

--- a/lib/bunny/session.rb
+++ b/lib/bunny/session.rb
@@ -223,6 +223,7 @@ module Bunny
       @transport_mutex     = @mutex_impl.new
       @status_mutex        = @mutex_impl.new
       @address_index_mutex = @mutex_impl.new
+      @recovery_mutex      = @mutex_impl.new
 
       @channels            = Hash.new
 
@@ -337,6 +338,10 @@ module Bunny
             @transport.maybe_initialize_socket
             @transport.post_initialize_socket
             @transport.connect
+          end
+
+          if @transport.read_timeout.nil?
+            @transport.read_timeout = @transport.connect_timeout || Transport::DEFAULT_READ_TIMEOUT
           end
 
           self.init_connection
@@ -805,30 +810,55 @@ module Bunny
 
       @status_mutex.synchronize { @status = :disconnected }
 
-      if !recovering_from_network_failure?
-        begin
+      acquired = @recovery_mutex.synchronize do
+        if @recovering_from_network_failure
+          false
+        else
           @recovering_from_network_failure = true
-          if recoverable_network_failure?(exception)
-            announce_network_failure_recovery
-            @channel_mutex.synchronize do
-              @channels.each do |n, ch|
-                ch.connection_closed!
-                ch.maybe_kill_consumer_work_pool!
-              end
-            end
-            @reader_loop.stop if @reader_loop
-            maybe_shutdown_heartbeat_sender
-
-            recover_connection_and_channels
-            recover_topology
-            mark_channels_after_recovery!
-            notify_of_recovery_completion
-          else
-            @logger.error "Exception #{exception.message} is considered unrecoverable..."
-          end
-        ensure
-          @recovering_from_network_failure = false
         end
+      end
+      return unless acquired
+
+      begin
+        if recoverable_network_failure?(exception)
+          announce_network_failure_recovery
+          @channel_mutex.synchronize do
+            @channels.each do |n, ch|
+              ch.connection_closed!
+              ch.maybe_kill_consumer_work_pool!
+            end
+          end
+          @reader_loop.stop if @reader_loop
+          maybe_shutdown_heartbeat_sender
+
+          loop do
+            break unless recover_connection_and_channels
+
+            recover_topology
+
+            if open?
+              mark_channels_after_recovery!
+              notify_of_recovery_completion
+              break
+            end
+
+            if should_retry_recovery?
+              decrement_recovery_attemp_counter!
+              announce_network_failure_recovery
+            else
+              @logger.error "Ran out of recovery attempts (limit set to #{@max_recovery_attempts}), giving up"
+              @transport.close
+              self.close(false)
+              @manually_closed = false
+              notify_of_recovery_attempts_exhausted
+              break
+            end
+          end
+        else
+          @logger.error "Exception #{exception.message} is considered unrecoverable..."
+        end
+      ensure
+        @recovery_mutex.synchronize { @recovering_from_network_failure = false }
       end
     end
 
@@ -841,7 +871,7 @@ module Bunny
     # @return [Boolean]
     # @private
     def recovering_from_network_failure?
-      @recovering_from_network_failure
+      @recovery_mutex.synchronize { @recovering_from_network_failure }
     end
 
     # @param [Bunny::Queue] queue
@@ -982,7 +1012,6 @@ module Bunny
       self.start
 
       if open?
-        @recovering_from_network_failure = false
         @logger.debug "Connection is now open"
         if @reset_recovery_attempt_counter_after_reconnection
           @logger.debug "Resetting recovery attempt counter after successful reconnection"
@@ -992,6 +1021,9 @@ module Bunny
         end
 
         recover_channels
+        true
+      else
+        raise TCPConnectionFailed.new("connection is not open after a connection recovery attempt", @transport.host, @transport.port)
       end
     rescue HostListDepleted
       reset_address_index
@@ -1010,6 +1042,7 @@ module Bunny
           self.close(false)
           @manually_closed = false
           notify_of_recovery_attempts_exhausted
+          false
         end
       else
         raise e
@@ -1086,7 +1119,7 @@ module Bunny
       exchanges.each do |x|
         begin
           recover_exchange(x)
-        rescue Exception => e
+        rescue ::StandardError => e
           @logger.error "Caught an exception while recovering exchange #{x.name}: #{e.inspect}"
         end
       end
@@ -1095,7 +1128,7 @@ module Bunny
       queues.each do |q|
         begin
           recover_queue(q)
-        rescue Exception => e
+        rescue ::StandardError => e
           @logger.error "Caught an exception while recovering queue #{q.name}: #{e.inspect}"
         end
       end
@@ -1104,7 +1137,7 @@ module Bunny
       queue_bindings.each do |b|
         begin
           recover_queue_binding(b)
-        rescue Exception => e
+        rescue ::StandardError => e
           @logger.error "Caught an exception while recovering a binding of queue #{b.destination}: #{e.inspect}"
         end
       end
@@ -1112,14 +1145,18 @@ module Bunny
       exchange_bindings.each do |b|
         begin
           recover_exchange_binding(b)
-        rescue Exception => e
+        rescue ::StandardError => e
           @logger.error "Caught an exception while recovering a binding of exchange #{b.source}: #{e.inspect}"
         end
       end
 
       @logger.debug { "Will recover #{consumers.size} consumer(s)" }
       consumers.each do |c|
-        recover_consumer(c)
+        begin
+          recover_consumer(c)
+        rescue ::StandardError => e
+          @logger.error "Caught an exception while recovering consumer #{c.consumer_tag} on queue #{c.queue_name}: #{e.inspect}"
+        end
       end
     end
 
@@ -1612,9 +1649,11 @@ module Bunny
       # We set the read_write_timeout to twice the heartbeat value,
       # and then some padding for edge cases.
       # This allows us to miss a single heartbeat before we time out the socket.
-      # If heartbeats are disabled, assume that TCP keepalives or a similar mechanism will be used
-      # and disable socket read timeouts. See ruby-amqp/bunny#551.
-      @transport.read_timeout = @heartbeat * 2.2
+      # If heartbeats are disabled, socket read timeouts will be disabled as well,
+      # but only after negotiation completes: a peer that accepts TCP connections
+      # without servicing them must not be able to block the handshake
+      # indefinitely. See ruby-amqp/bunny#551.
+      @transport.read_timeout = @heartbeat * 2.2 if @heartbeat > 0
       @logger.debug { "Will use socket read timeout of #{@transport.read_timeout.to_i} seconds" }
 
       # if there are existing channels we've just recovered from
@@ -1645,33 +1684,38 @@ module Bunny
       end
       connection_open_ok = frame2.decode_payload
 
-      @status_mutex.synchronize { @status = :open }
-      if @heartbeat && @heartbeat > 0
-        initialize_heartbeat_sender
-      end
-
       unless connection_open_ok.is_a?(AMQ::Protocol::Connection::OpenOk)
         if connection_open_ok.is_a?(AMQ::Protocol::Connection::Close)
           e = instantiate_connection_level_exception(connection_open_ok)
+          raise e if automatically_recover?
+
           begin
             shut_down_all_consumer_work_pools!
             maybe_shutdown_reader_loop
           rescue ShutdownSignal => _sse
             # no-op
-          rescue Exception => e
-            @logger.warn "Caught an exception when cleaning up after receiving connection.close: #{e.message}"
+          rescue Exception => cleanup_exception
+            @logger.warn "Caught an exception when cleaning up after receiving connection.close: #{cleanup_exception.message}"
           ensure
             close_transport
           end
 
           if threaded?
             @session_error_handler.raise(e)
+            return
           else
             raise e
           end
         else
           raise "could not open connection: server did not respond with connection.open-ok but #{connection_open_ok.inspect} instead"
         end
+      end
+
+      @status_mutex.synchronize { @status = :open }
+      if @heartbeat && @heartbeat > 0
+        initialize_heartbeat_sender
+      else
+        @transport.read_timeout = 0
       end
     end
 

--- a/spec/higher_level_api/integration/connection_recovery_during_negotiation_spec.rb
+++ b/spec/higher_level_api/integration/connection_recovery_during_negotiation_spec.rb
@@ -1,0 +1,219 @@
+# -*- coding: utf-8 -*-
+# frozen_string_literal: true
+
+require "spec_helper"
+require "socket"
+
+describe "Connection recovery when the server closes connections during negotiation" do
+  # An in-process TCP proxy in front of the RabbitMQ node used by the test
+  # suite. In poisoned mode it lets the AMQP handshake proceed and then
+  # answers connection.open with connection.close (CONNECTION_FORCED), the
+  # way a node that is being drained (put into maintenance mode) before a
+  # shutdown does. It can also close established client connections with a
+  # server-sent connection.close, like `rabbitmqctl close_all_connections`.
+  class NegotiationPoisoningProxy
+    # method frame payload prefix: class 10 (connection), method 40 (open)
+    CONNECTION_OPEN_SIGNATURE = "\x00\x0A\x00\x28".b
+
+    CONNECTION_FORCED_FRAME = AMQ::Protocol::Connection::Close.encode(
+      320, "CONNECTION_FORCED - Node was put into maintenance mode", 0, 0).encode
+
+    attr_reader :port
+
+    def initialize(upstream_host: "127.0.0.1", upstream_port: Integer(ENV.fetch("RABBITMQ_PORT", 5672)))
+      @upstream_host = upstream_host
+      @upstream_port = upstream_port
+
+      @server = TCPServer.new("127.0.0.1", 0)
+      @port   = @server.addr[1]
+
+      @lock              = Mutex.new
+      @poisoning         = false
+      @poisoned_attempts = 0
+      @clients           = []
+      @threads           = []
+    end
+
+    def poison!
+      @lock.synchronize { @poisoning = true }
+    end
+
+    def heal!
+      @lock.synchronize { @poisoning = false }
+    end
+
+    def poisoning?
+      @lock.synchronize { @poisoning }
+    end
+
+    # @return [Integer] how many connection attempts were rejected during negotiation
+    def poisoned_attempts
+      @lock.synchronize { @poisoned_attempts }
+    end
+
+    # Closes all established client connections with a server-sent
+    # connection.close, like a node that is being put into maintenance mode.
+    def force_close_established!
+      @lock.synchronize { @clients.dup }.each do |client|
+        begin
+          client.write(CONNECTION_FORCED_FRAME)
+        rescue IOError, SystemCallError
+          # the client is already gone
+        end
+      end
+    end
+
+    def start
+      @acceptor = Thread.new do
+        loop do
+          begin
+            client = @server.accept
+          rescue IOError, SystemCallError
+            break
+          end
+          @lock.synchronize { @clients << client }
+          @threads << Thread.new(client) { |c| pump(c) }
+        end
+      end
+      self
+    end
+
+    def stop
+      @server.close rescue nil
+      @acceptor.kill if @acceptor
+      @threads.each(&:kill)
+      @lock.synchronize { @clients.dup }.each { |c| c.close rescue nil }
+    end
+
+    private
+
+    def pump(client)
+      upstream = TCPSocket.new(@upstream_host, @upstream_port)
+
+      upstream_to_client = Thread.new do
+        begin
+          loop { client.write(upstream.readpartial(65536)) }
+        rescue EOFError, IOError, SystemCallError
+        ensure
+          client.close rescue nil
+          upstream.close rescue nil
+        end
+      end
+
+      begin
+        loop do
+          data = client.readpartial(65536)
+          if poisoning? && data.include?(CONNECTION_OPEN_SIGNATURE)
+            @lock.synchronize { @poisoned_attempts += 1 }
+            client.write(CONNECTION_FORCED_FRAME)
+            sleep 0.2
+            break
+          end
+          upstream.write(data)
+        end
+      rescue EOFError, IOError, SystemCallError
+      ensure
+        upstream.close rescue nil
+        client.close rescue nil
+        upstream_to_client.join
+      end
+    ensure
+      @lock.synchronize { @clients.delete(client) }
+    end
+  end
+
+  # Records exceptions Bunny raises into the session thread instead of
+  # letting them terminate it, so that the test can assert on them.
+  class RecordingSessionErrorHandler
+    def initialize
+      @lock       = Mutex.new
+      @exceptions = []
+    end
+
+    def raise(e)
+      @lock.synchronize { @exceptions << e }
+    end
+
+    def exceptions
+      @lock.synchronize { @exceptions.dup }
+    end
+  end
+
+  let(:logger) { Logger.new($stderr).tap { |l| l.level = ENV.fetch("BUNNY_LOG_LEVEL", Logger::WARN) } }
+
+  def poll_until(&probe)
+    Bunny::TestKit.poll_until(30, &probe)
+  end
+
+  it "keeps retrying and recovers once the node stops rejecting connections, without raising into the session thread" do
+    proxy = NegotiationPoisoningProxy.new.start
+    error_handler = RecordingSessionErrorHandler.new
+
+    c = Bunny.new(host: "127.0.0.1",
+                  port: proxy.port,
+                  network_recovery_interval: 0.2,
+                  recover_from_connection_close: true,
+                  session_error_handler: error_handler,
+                  logger: logger)
+    c.start
+
+    begin
+      ch = c.create_channel
+      q  = ch.queue("bunny.recovery.negotiation", exclusive: true)
+
+      deliveries = Queue.new
+      q.subscribe { |_di, _mp, payload| deliveries.push(payload) }
+
+      q.publish("before")
+      poll_until { deliveries.length == 1 }
+
+      # The node begins to drain: established connections are force-closed
+      # and reconnection attempts are rejected during negotiation.
+      proxy.poison!
+      proxy.force_close_established!
+
+      # Recovery must survive several rejected attempts...
+      poll_until { proxy.poisoned_attempts >= 3 }
+
+      # ...and complete as soon as the node is accepting clients again.
+      proxy.heal!
+      poll_until { c.open? && ch.open? }
+
+      q.publish("after")
+      poll_until { deliveries.length == 2 }
+      expect(deliveries.pop).to eq "before"
+      expect(deliveries.pop).to eq "after"
+
+      # connection.close during negotiation is handled by the recovery
+      # retry logic and is not raised into the session thread
+      expect(error_handler.exceptions).to be_empty
+    ensure
+      c.close(false) rescue nil
+      proxy.stop
+    end
+  end
+
+  it "times out negotiation with a peer that accepts TCP connections but never responds, even with read timeouts disabled" do
+    # A "black hole": accepts TCP connections and never writes anything back,
+    # like a suspended listener of a node in maintenance mode or an endpoint
+    # of a Kubernetes pod whose node was abruptly terminated.
+    black_hole = TCPServer.new("127.0.0.1", 0)
+    port = black_hole.addr[1]
+
+    c = Bunny.new(host: "127.0.0.1",
+                  port: port,
+                  read_timeout: 0,
+                  connection_timeout: 2,
+                  logger: logger)
+
+    started_at = Bunny::Timestamp.monotonic
+    expect do
+      # the outer timeout turns a regression (an indefinitely blocked
+      # handshake) into a fast, clean failure via the elapsed time check below
+      Timeout.timeout(15) { c.start }
+    end.to raise_error(::Timeout::Error)
+    expect(Bunny::Timestamp.monotonic - started_at).to be < 10
+  ensure
+    black_hole.close rescue nil
+  end
+end

--- a/spec/unit/session_recovery_spec.rb
+++ b/spec/unit/session_recovery_spec.rb
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+# frozen_string_literal: true
+require "spec_helper"
+
+describe Bunny::Session do
+  # These examples exercise the connection recovery orchestration logic
+  # in isolation, without a running RabbitMQ node: connection-level
+  # operations are stubbed out. End-to-end recovery behavior is covered
+  # by the integration specs.
+
+  let(:logger) { Logger.new(IO::NULL) }
+
+  def new_session(opts = {})
+    Bunny.new({
+      host: "127.0.0.1",
+      port: 65_534,
+      network_recovery_interval: 0,
+      logger: logger
+    }.merge(opts))
+  end
+
+  describe "#handle_network_failure" do
+    it "runs a single recovery when failures are reported concurrently" do
+      session = new_session
+
+      recovery_started  = Queue.new
+      release_recovery  = Queue.new
+
+      allow(session).to receive(:recover_connection_and_channels) do
+        recovery_started.push(true)
+        release_recovery.pop
+        true
+      end
+      allow(session).to receive(:recover_topology)
+      allow(session).to receive(:notify_of_recovery_completion)
+      allow(session).to receive(:open?).and_return(true)
+
+      first = Thread.new { session.handle_network_failure(IOError.new("first")) }
+      recovery_started.pop
+
+      # a second failure signal arrives while a recovery is in progress,
+      # e.g. from a publishing thread that ran into a write error
+      second = Thread.new { session.handle_network_failure(IOError.new("second")) }
+      second.join
+      expect(session.recovering_from_network_failure?).to be true
+
+      release_recovery.push(true)
+      first.join
+
+      expect(session.recovering_from_network_failure?).to be false
+      expect(session).to have_received(:recover_connection_and_channels).once
+    end
+
+    it "runs another full recovery round when the connection is lost again mid-recovery" do
+      session = new_session
+
+      rounds = 0
+      allow(session).to receive(:recover_connection_and_channels) { rounds += 1; true }
+      allow(session).to receive(:recover_topology)
+      allow(session).to receive(:notify_of_recovery_completion)
+      # the connection is gone again by the time topology recovery finished,
+      # e.g. the node was drained one more time before shutting down
+      allow(session).to receive(:open?).and_return(false, true)
+
+      session.handle_network_failure(IOError.new("node is being drained"))
+
+      expect(rounds).to eq 2
+      expect(session).to have_received(:notify_of_recovery_completion).once
+    end
+
+    it "gives up mid-recovery rounds when recovery attempts are exhausted" do
+      exhausted = false
+      session = new_session(recovery_attempts: 1,
+                            recovery_attempts_exhausted: -> { exhausted = true },
+                            reset_recovery_attempts_after_reconnection: false)
+
+      allow(session).to receive(:recover_connection_and_channels).and_return(true)
+      allow(session).to receive(:recover_topology)
+      allow(session).to receive(:notify_of_recovery_completion)
+      allow(session).to receive(:open?).and_return(false)
+      allow(session).to receive(:close)
+
+      session.handle_network_failure(IOError.new("node is gone"))
+
+      expect(exhausted).to be true
+      expect(session).not_to have_received(:notify_of_recovery_completion)
+      expect(session.recovering_from_network_failure?).to be false
+    end
+
+    it "releases the recovery guard when a recovery round raises" do
+      session = new_session
+
+      allow(session).to receive(:recover_connection_and_channels).and_raise(RuntimeError, "unexpected")
+
+      expect do
+        session.handle_network_failure(IOError.new("failure"))
+      end.to raise_error(RuntimeError, "unexpected")
+
+      expect(session.recovering_from_network_failure?).to be false
+    end
+
+    it "does not attempt recovery for exceptions that are not recoverable" do
+      session = new_session
+      session.recoverable_exceptions = [IOError]
+
+      allow(session).to receive(:recover_connection_and_channels)
+
+      session.handle_network_failure(SignalException.new("TERM"))
+
+      expect(session).not_to have_received(:recover_connection_and_channels)
+      expect(session.recovering_from_network_failure?).to be false
+    end
+  end
+
+  describe "#recover_connection_and_channels" do
+    it "treats a connection that did not reach the open state as a failed attempt" do
+      exhausted = false
+      session = new_session(recovery_attempts: 1,
+                            recovery_attempts_exhausted: -> { exhausted = true },
+                            reset_recovery_attempts_after_reconnection: false)
+
+      allow(session).to receive(:initialize_transport)
+      allow(session).to receive(:start)
+      allow(session).to receive(:open?).and_return(false)
+      allow(session).to receive(:close)
+      allow(session).to receive(:recover_channels)
+
+      expect(session.send(:recover_connection_and_channels)).to be false
+      expect(exhausted).to be true
+      expect(session).not_to have_received(:recover_channels)
+    end
+
+    it "returns true and recovers channels when the connection is open again" do
+      session = new_session
+
+      allow(session).to receive(:initialize_transport)
+      allow(session).to receive(:start)
+      allow(session).to receive(:open?).and_return(true)
+      allow(session).to receive(:recover_channels)
+
+      expect(session.send(:recover_connection_and_channels)).to be true
+      expect(session).to have_received(:recover_channels)
+    end
+  end
+
+  describe "#recover_topology" do
+    it "attempts to recover the remaining consumers when one of them fails" do
+      session = new_session
+      channel = double("channel")
+
+      session.record_consumer_with(channel, "tag-1", "q-1", proc {}, true, false, {})
+      session.record_consumer_with(channel, "tag-2", "q-2", proc {}, true, false, {})
+
+      recovered = []
+      allow(session).to receive(:recover_consumer) do |rc|
+        recovered << rc.consumer_tag
+        raise "boom" if rc.consumer_tag == "tag-1"
+      end
+
+      expect { session.send(:recover_topology) }.not_to raise_error
+      expect(recovered.sort).to eq %w[tag-1 tag-2]
+    end
+  end
+end


### PR DESCRIPTION
## Symptoms

A client with `automatically_recover` enabled (the default) can get permanently stuck after a RabbitMQ node closes its connections when being put into maintenance mode. The typical environment is RabbitMQ on Kubernetes with periodic node rotation (e.g. Karpenter), where the node is drained before shutdown:

```
W ... Recovering from connection.close (CONNECTION_FORCED - Node was put into maintenance mode)
W ... Will recover from a network failure (no retry limit)...
W ... Retrying connection on next host in line: rabbitmq.svc.cluster.local:5672
W ... Recovering from connection.close (CONNECTION_FORCED - Node was put into maintenance mode)   <- a second close ~1 minute later
W ... Will recover from a network failure (no retry limit)...
W ... Retrying connection on next host in line: rabbitmq.svc.cluster.local:5672
                                                <- nothing else, ever
```

After that: the process is alive, Bunny logs nothing further, all recovery retries have stopped, consumers are gone. The management UI may show an established connection with **zero channels** on it - the heartbeat sender keeps the TCP connection alive, but channels and consumers are never recovered. The hang is rare and irregular (once per several days in our case) because it is a race.

## Root cause

A node that is being drained closes client connections more than once: first the established ones, then freshly reconnected clients - including **in the middle of the AMQP handshake**, where the client receives `connection.close (CONNECTION_FORCED)` instead of `connection.open-ok`. From there, three defects chain together:

1. **`connection.close` during negotiation silently terminates recovery.** In the close-instead-of-open-ok branch of `Session#open_connection`, the exception is delivered via `@session_error_handler.raise(e)` - with the default `ExceptionAccumulator` it is silently stored away; with the legacy `Thread` handler it is raised asynchronously in an unrelated application thread. Either way, the method then returns normally, `recover_connection_and_channels` sees `open? == false` and simply returns - no retry, no log line. The recovery process is dead.

2. **The recovery guard is not atomic and is cleared too early.** `Session#handle_network_failure` can be invoked concurrently - from the reader loop and from application threads that run into socket write failures (`Transport#write` / `Transport#send_frame`). The `if !recovering_from_network_failure?` check is an unsynchronized check-then-act, and the flag was cleared before channel and topology recovery completed. As a result, either two overlapping recoveries sabotage each other (`initialize_transport` closes the other recovery's transport), or a failure signal that arrives mid-recovery is silently dropped. After defect (1), the client only survived thanks to an accidental re-trigger: `Session#start` had already started a new reader loop on the by-then-closed transport, that loop immediately died with an `IOError` and re-entered `handle_network_failure` - *unless* its signal landed inside the window where the guard flag was still set. When it did, no thread was left to continue the recovery. This is the probabilistic once-per-N-days hang.

3. **Negotiation could block indefinitely.** A peer that accepts TCP connections but never responds at the protocol level (suspended listeners of a node in maintenance mode; a black hole after the node is terminated without FIN/RST) blocks `init_connection` in `read_next_frame` forever when socket read timeouts are disabled - and the whole recovery loop with it.

Additionally, `@status = :open` and the heartbeat sender were set up *before* validating that the frame received was actually `connection.open-ok`, so a heartbeat sender could be started on the transport of a connection that was already doomed.

## Compatibility notes

One behavior change: with `automatically_recover: true`, a negotiation-time `connection.close` no longer goes to the session error handler - it is handled by recovery retries. With automatic recovery disabled, behavior is unchanged. The read timeout change only affects the negotiation phase.
