### PR TITLE
Push the gem from CI via trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: Push gem
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+*"
+
+permissions:
+  contents: read
+
+jobs:
+  push:
+    name: Push Bunny to RubyGems.org
+    # Tags pushed in a fork must not attempt a release
+    if: github.repository == 'ruby-amqp/bunny'
+    runs-on: ubuntu-latest
+
+    concurrency:
+      group: push-gem
+      cancel-in-progress: false
+
+    environment:
+      name: release
+      url: https://rubygems.org/gems/bunny
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: "4.0"
+
+      - name: Verify the tag matches Bunny::VERSION
+        env:
+          TAG: ${{ github.ref_name }}
+        run: test "$TAG" = "$(ruby -Ilib -rbunny/version -e 'print Bunny::VERSION')"
+
+      - name: Configure trusted publishing credentials
+        uses: rubygems/configure-rubygems-credentials@dc5a8d8553e6ee01fc26761a49e99e733d17954a # v2.1.0
+
+      - name: Build the gem
+        env:
+          TAG: ${{ github.ref_name }}
+        run: gem build bunny.gemspec --output "bunny-${TAG}.gem"
+
+      - name: Push to RubyGems.org
+        env:
+          TAG: ${{ github.ref_name }}
+        run: gem push "bunny-${TAG}.gem"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,12 @@ existing writing style.
 
 ## Releases
 
+Releases are published by `.github/workflows/release.yml`, which reacts to a
+pushed version tag and pushes the gem to RubyGems.org using
+[trusted publishing](https://guides.rubygems.org/trusted-publishing/), so no
+RubyGems credentials are needed locally. The workflow refuses to publish unless
+the tag matches `Bunny::VERSION`.
+
 ### How to Roll (Produce) a New Release
 
 Suppose the current development version in `ChangeLog.md` has
@@ -36,6 +42,7 @@ To produce a new release:
  5. Bump the dev version: add a new `## Changes between Bunny X.(Y+1).0 and X.(Y+2).0 (in development)` section to `ChangeLog.md` with `No changes yet.` underneath, and update `lib/bunny/version.rb` to the next dev version with a `.pre` suffix
  6. Commit with the message `Bump dev version`
  7. Push: `git push && git push origin X.(Y+1).0`
+ 8. Watch the release: `gh run watch --workflow=release.yml`
 
 
 ## Git Instructions


### PR DESCRIPTION
Publishes the gem from CI on a version tag using [trusted publishing](https://guides.rubygems.org/trusted-publishing/), same as ruby-amqp/amq-protocol#90.

Two things are needed before the first release goes through:

* a GitHub environment named `release` (Settings > Environments). Without it the job fails with `environment not found` before any step runs
* a trusted publisher for the `bunny` gem on RubyGems.org pointing at this repository, workflow `release.yml`, environment `release`

This does not use `rubygems/release-gem`, unlike amq-protocol. That action runs `bundle exec rake release`, and Bundler's `version_tag` is hardcoded to `v#{version}`. Bunny tags releases as `3.2.0`, so `already_tagged?` would never match, and the task would create a second `v3.3.0` tag and try to push it from a detached checkout. Building and pushing the gem directly keeps the tag convention as it is. Recent RubyGems versions sign trusted publishing pushes on their own, so attestations work either way.

The tag filter accepts `3.3.0` and `3.3.0.pre`, and the job refuses to publish unless the tag matches `Bunny::VERSION`, so a mistyped tag is a failed run instead of a bad release.
