### PR TITLE
connect_timeout for the TLS handshake

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,17 @@
 ## Changes between Bunny 3.3.0 and 3.4.0 (in development)
 
-No changes yet.
+### TLS Handshake is Now Covered by the Connection Timeout
+
+The TLS handshake was the only connection establishment step not limited
+by any timeout. A peer that accepted a TCP connection but never completed
+the handshake (e.g. a load balancer in front of an unresponsive node)
+could block `Bunny::Session#start`, and with it connection recovery,
+indefinitely.
+
+The handshake now uses the same `connect_timeout` setting as the TCP
+connection step (default: 30 seconds) and raises a recoverable
+`Bunny::ClientTimeout` when the timeout is exceeded. Use
+`connect_timeout: 0` to opt out.
 
 
 ## Changes between Bunny 3.2.0 and 3.3.0 (Aug 29, 2026)

--- a/lib/bunny/cruby/ssl_socket.rb
+++ b/lib/bunny/cruby/ssl_socket.rb
@@ -21,7 +21,13 @@ module Bunny
       end
 
       # Performs the TLS handshake with an optional time limit
-      def connect_with_deadline(timeout = nil)
+      #
+      # @param [Numeric] timeout Timeout in seconds, nil or 0 means no time limit
+      #
+      # @return [Bunny::SSLSocket] self
+      # @raise [Bunny::ClientTimeout] if the handshake does not complete within the timeout
+      # @api public
+      def connect_with_timeout(timeout = nil)
         return connect if timeout.nil? || timeout <= 0
 
         deadline = Bunny::Timestamp.monotonic + timeout

--- a/lib/bunny/cruby/ssl_socket.rb
+++ b/lib/bunny/cruby/ssl_socket.rb
@@ -20,6 +20,31 @@ module Bunny
         @__bunny_socket_eof_flag__ = false
       end
 
+      # Performs the TLS handshake with an optional time limit
+      def connect_with_deadline(timeout = nil)
+        return connect if timeout.nil? || timeout <= 0
+
+        deadline = Bunny::Timestamp.monotonic + timeout
+        begin
+          connect_nonblock
+        rescue *READ_RETRY_EXCEPTION_CLASSES
+          remaining = deadline - Bunny::Timestamp.monotonic
+          if remaining > 0 && IO.select([self], nil, nil, remaining)
+            retry
+          else
+            raise ClientTimeout, "TLS handshake timed out after #{timeout} seconds"
+          end
+        rescue *WRITE_RETRY_EXCEPTION_CLASSES
+          remaining = deadline - Bunny::Timestamp.monotonic
+          if remaining > 0 && IO.select(nil, [self], nil, remaining)
+            retry
+          else
+            raise ClientTimeout, "TLS handshake timed out after #{timeout} seconds"
+          end
+        end
+        self
+      end
+
       # Reads given number of bytes with an optional timeout
       #
       # @param [Integer] count How many bytes to read

--- a/lib/bunny/transport.rb
+++ b/lib/bunny/transport.rb
@@ -108,7 +108,11 @@ module Bunny
     def connect
       if uses_tls?
         begin
-          @socket.connect
+          @socket.connect_with_deadline(@connect_timeout)
+        rescue ClientTimeout => e
+          @logger.error { "TLS handshake timed out after #{@connect_timeout} seconds" }
+          close
+          raise e
         rescue OpenSSL::SSL::SSLError => e
           @logger.error { "TLS connection failed: #{e.message}" }
           raise e

--- a/lib/bunny/transport.rb
+++ b/lib/bunny/transport.rb
@@ -108,9 +108,9 @@ module Bunny
     def connect
       if uses_tls?
         begin
-          @socket.connect_with_deadline(@connect_timeout)
+          @socket.connect_with_timeout(@connect_timeout)
         rescue ClientTimeout => e
-          @logger.error { "TLS handshake timed out after #{@connect_timeout} seconds" }
+          @logger.error { "TLS connection failed: #{e.message}" }
           close
           raise e
         rescue OpenSSL::SSL::SSLError => e

--- a/spec/unit/tls_handshake_timeout_spec.rb
+++ b/spec/unit/tls_handshake_timeout_spec.rb
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+# frozen_string_literal: true
+require "spec_helper"
+
+describe Bunny::SSLSocket, "#connect_with_timeout" do
+  # TCP server that accepts connections but never performs the TLS handshake
+  # (like a load balancer in front of an unresponsive node)
+  def with_silent_tcp_server
+    server = TCPServer.new("127.0.0.1", 0)
+    yield server.addr[1]
+  ensure
+    server.close
+  end
+
+  def new_client_socket(port)
+    ctx = OpenSSL::SSL::SSLContext.new
+    ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    socket = Bunny::SSLSocket.new(TCPSocket.new("127.0.0.1", port), ctx)
+    socket.sync_close = true
+    socket
+  end
+
+  it "raises Bunny::ClientTimeout when the peer never completes the handshake" do
+    with_silent_tcp_server do |port|
+      socket = new_client_socket(port)
+      started_at = Bunny::Timestamp.monotonic
+
+      expect { socket.connect_with_timeout(0.5) }.to raise_error(Bunny::ClientTimeout)
+
+      elapsed = Bunny::Timestamp.monotonic - started_at
+      expect(elapsed).to be >= 0.4
+      expect(elapsed).to be < 5
+
+      socket.close
+    end
+  end
+end
+
+describe Bunny::Session, "#start over TLS" do
+  let(:logger) { Logger.new(IO::NULL) }
+
+  def with_silent_tcp_server
+    server = TCPServer.new("127.0.0.1", 0)
+    yield server.addr[1]
+  ensure
+    server.close
+  end
+
+  it "raises Bunny::ClientTimeout instead of blocking when the peer never completes the handshake" do
+    with_silent_tcp_server do |port|
+      conn = Bunny.new(host: "127.0.0.1",
+                       port: port,
+                       tls: true,
+                       verify_peer: false,
+                       connect_timeout: 0.5,
+                       automatically_recover: false,
+                       logger: logger)
+      started_at = Bunny::Timestamp.monotonic
+
+      expect { conn.start }.to raise_error(Bunny::ClientTimeout)
+      expect(Bunny::Timestamp.monotonic - started_at).to be < 5
+    end
+  end
+end


### PR DESCRIPTION
Bunny applies several timeouts:
- `connect_timeout` to the TCP connection step
- `read_timeout` and `write_timeout` to the read and write operations

But it does not apply a timeout to the TLS handshake.

`Bunny::Transport#connect` calls `OpenSSL::SSL::SSLSocket#connect`. This call can block the thread for an unlimited time. This condition occurs when a peer accepts the TCP connection, but does not complete the TLS handshake. One example of such a peer is a load balancer in front of a RabbitMQ node that is out of operation.

We had more than one incident of this type after network problems. In each incident, Bunny stopped consumption of messages from RabbitMQ and did not continue. The connection did not recover, and no error was visible. A restart of the process was the only solution.

## Steps to Reproduce

1. Start a TCP server that accepts connections, but does not send data:
`nc -lk 15671`
2. Start a TLS connection to this server:
```ruby
conn = Bunny.new(host: "127.0.0.1", port: 15671, tls: true,
verify_peer: false, connect_timeout: 5)
conn.start
```
3. Wait for more than 5 seconds.

Expected behavior: Bunny::Session#start raises a timeout
Actual behaviour: Bunny::Session#start blocks for an unlimited time.

## Changes:

* Adds `Bunny::SSLSocket#connect_with_timeout`. The method does the TLS handshake with a time limit
* The TCP connection step already raises `Bunny::ClientTimeout` on a timeout. The handshake step now raises the same exception class
* Use `connect_timeout: 0` to disable the time limit. This setting gives the old behavior