### PR TITLE
Apply connect_timeout to the TLS handshake, require Ruby 3.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ an AMQP 0-9-1 protocol parser (more specifically: a serialization, deserializati
 
 ## Target Ruby Version
 
-This library targets Ruby 3.0 and later versions.
+This library targets Ruby 3.2 and later versions.
 
 ## Comments
 
@@ -65,7 +65,7 @@ and for deviations from the instructions in this file.
 
 In particular, check that:
 
- * The code targets Ruby 3.0 and does not rely on newer-version features
+ * The code targets Ruby 3.2 and does not rely on newer-version features
  * Notable user-visible changes are listed in `ChangeLog.md` under the current `(in development)` section
  * New behavior is covered by tests under `spec/unit`, `spec/higher_level_api`, or `spec/lower_level_api`
  * No new runtime dependencies were introduced beyond `amq-protocol`

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,12 @@
 ## Changes between Bunny 3.3.0 and 3.4.0 (in development)
 
-No changes yet.
+### TLS Handshake Now Respects `connect_timeout`
+
+A peer that accepted the TCP connection but never completed the TLS handshake
+could block `Bunny::Session#start` indefinitely. The handshake now gives up after
+`connect_timeout` and the connection fails over to the next endpoint.
+
+This requires the `openssl` gem `3.3.0` or later.
 
 
 ## Changes between Bunny 3.2.0 and 3.3.0 (Aug 29, 2026)

--- a/bunny.gemspec
+++ b/bunny.gemspec
@@ -26,6 +26,8 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "amq-protocol", "~> 2.9"
   s.add_runtime_dependency "logger", "~> 1", ">= 1.7"
+  # 3.3 is the first version whose SSLSocket#connect honours IO#timeout
+  s.add_runtime_dependency "openssl", ">= 3.3"
   s.add_runtime_dependency "sorted_set", "~> 1", ">= 1.0.2"
 
   s.extra_rdoc_files = ["README.md"]

--- a/bunny.gemspec
+++ b/bunny.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.summary = "Popular easy to use Ruby client for RabbitMQ"
   s.description = "Easy to use, feature complete Ruby client for RabbitMQ 3.9 and later versions."
   s.license = "MIT"
-  s.required_ruby_version = ">= 3.0"
+  s.required_ruby_version = ">= 3.2"
 
   s.metadata = {
     "changelog_uri" => "https://github.com/ruby-amqp/bunny/blob/main/ChangeLog.md",

--- a/lib/bunny/transport.rb
+++ b/lib/bunny/transport.rb
@@ -108,7 +108,12 @@ module Bunny
     def connect
       if uses_tls?
         begin
-          @socket.connect
+          tls_handshake
+        rescue ClientTimeout => e
+          @logger.error { "TLS connection failed: #{e.message}" }
+          close
+          @status = :not_connected
+          raise Bunny::TCPConnectionFailed.new(e, self.hostname, self.port)
         rescue OpenSSL::SSL::SSLError => e
           @logger.error { "TLS connection failed: #{e.message}" }
           raise e
@@ -333,6 +338,17 @@ module Bunny
       end
 
       @socket
+    end
+
+    # Needs the openssl gem >= 3.3, which added SSLSocket#timeout= and made #connect honour it
+    def tls_handshake
+      previous_timeout = @socket.timeout
+      @socket.timeout = @connect_timeout if @connect_timeout
+      @socket.connect
+    rescue IO::TimeoutError
+      raise ClientTimeout, "TLS handshake timed out after #{@connect_timeout} seconds"
+    ensure
+      @socket.timeout = previous_timeout
     end
 
     def maybe_initialize_socket

--- a/spec/unit/tls_handshake_timeout_spec.rb
+++ b/spec/unit/tls_handshake_timeout_spec.rb
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+# frozen_string_literal: true
+require "spec_helper"
+
+describe Bunny::Session, "#start over TLS" do
+  let(:log) { StringIO.new }
+  let(:logger) { Logger.new(log) }
+
+  # servers that accept the connection but never speak TLS, like a load balancer in front of a dead node
+  def with_silent_tcp_servers(n)
+    servers = Array.new(n) { TCPServer.new("127.0.0.1", 0) }
+    yield servers.map { |s| s.addr[1] }
+  ensure
+    servers&.each(&:close)
+  end
+
+  def connection_to(ports, opts = {})
+    Bunny.new({ hosts: ports.map { |p| "127.0.0.1:#{p}" },
+                tls: true,
+                verify_peer: false,
+                connect_timeout: 0.5,
+                automatically_recover: false,
+                logger: logger }.merge(opts))
+  end
+
+  # the failure mode under test is an unbounded block, so bound the example itself
+  def start_connection(connection)
+    Bunny::Timeout.timeout(5) { connection.start }
+  end
+
+  def timed_out_on?(port)
+    log.string.match?(/127\.0\.0\.1:#{port}: TLS handshake timed out/)
+  end
+
+  it "gives up on a peer that never completes the handshake" do
+    with_silent_tcp_servers(1) do |ports|
+      expect { start_connection(connection_to(ports)) }.to raise_error(Bunny::TCPConnectionFailedForAllHosts)
+
+      expect(timed_out_on?(ports.first)).to be true
+    end
+  end
+
+  it "tries every endpoint" do
+    with_silent_tcp_servers(2) do |ports|
+      expect { start_connection(connection_to(ports)) }.to raise_error(Bunny::TCPConnectionFailedForAllHosts)
+
+      ports.each { |port| expect(timed_out_on?(port)).to be true }
+    end
+  end
+
+  it "does not limit the handshake when connect_timeout is 0" do
+    with_silent_tcp_servers(1) do |ports|
+      transport = connection_to(ports, connect_timeout: 0).transport
+      transport.maybe_initialize_socket
+      transport.post_initialize_socket
+      handshake = Thread.new { transport.connect }
+
+      expect(handshake.join(0.5)).to be_nil
+
+      handshake.kill
+    end
+  end
+end


### PR DESCRIPTION
Alternative to https://github.com/ruby-amqp/bunny/pull/745