### PR TITLE
Send the full client certificate chain

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 ## Changes between Bunny 3.3.0 and 3.4.0 (in development)
 
+### Client Certificate Chains
+
+`tls_cert` can now point at a bundle of the leaf certificate and its intermediate CAs.
+Only the leaf was presented before, failing mTLS against brokers that trust the root alone.
+
+GitHub issue: [#749](https://github.com/ruby-amqp/bunny/issues/749)
+
+
 ### TLS Handshake Now Respects `connect_timeout`
 
 A peer that accepted the TCP connection but never completed the TLS handshake

--- a/lib/bunny/transport.rb
+++ b/lib/bunny/transport.rb
@@ -497,7 +497,12 @@ module Bunny
     end
 
     def initialize_tls_context(ctx, opts = {})
-      ctx.cert       = OpenSSL::X509::Certificate.new(@tls_certificate) if @tls_certificate
+      if @tls_certificate
+        leaf, *chain = OpenSSL::X509::Certificate.load(@tls_certificate)
+
+        ctx.cert = leaf
+        ctx.extra_chain_cert = chain unless chain.empty?
+      end
       ctx.key        = OpenSSL::PKey.read(@tls_key) if @tls_key
       ctx.cert_store = if @tls_certificate_store
                          @tls_certificate_store

--- a/spec/unit/tls_client_certificate_chain_spec.rb
+++ b/spec/unit/tls_client_certificate_chain_spec.rb
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# frozen_string_literal: true
+require "spec_helper"
+require "tempfile"
+
+describe Bunny::Session, "TLS client certificate" do
+  let(:leaf) { File.read("spec/tls/client_certificate.pem") }
+  let(:ca) { File.read("spec/tls/ca_certificate.pem") }
+
+  def context_for(certificate)
+    Tempfile.create(["client_certificate", ".pem"]) do |f|
+      f.write(certificate)
+      f.flush
+
+      Bunny.new(tls: true, tls_cert: f.path, tls_key: "spec/tls/client_key.pem").transport.tls_context
+    end
+  end
+
+  it "uses the certificate as is when the file holds a single one" do
+    ctx = context_for(leaf)
+
+    expect(ctx.cert.to_pem).to eq(leaf)
+    expect(ctx.extra_chain_cert).to be_nil
+  end
+
+  # what cert-manager writes into tls.crt: the leaf, then the CAs that chain it to a root
+  it "presents the rest of the bundle alongside the leaf" do
+    ctx = context_for(leaf + ca)
+
+    expect(ctx.cert.to_pem).to eq(leaf)
+    expect(ctx.extra_chain_cert.map(&:to_pem)).to eq([ca])
+  end
+
+  it "still rejects a file that does not hold a certificate" do
+    expect { context_for("not a certificate") }.to raise_error(OpenSSL::X509::CertificateError)
+  end
+end


### PR DESCRIPTION
`OpenSSL::X509::Certificate.new` keeps only the first PEM, so a leaf + intermediate bundle in `tls_cert` lost the intermediates and mTLS against a root-only broker failed with `tlsv1 alert unknown ca`. `Certificate.load` reads the whole bundle: leaf into `ctx.cert`, the rest into `ctx.extra_chain_cert`. Single-certificate files are unaffected.

Fixes #749